### PR TITLE
Minimally fix typing issues

### DIFF
--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -55,7 +55,7 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
         """Computes the loss given the training objects."""
 
 
-class PFBasedGFlowNet(GFlowNet, Generic[TrainingSampleType]):
+class PFBasedGFlowNet(GFlowNet[TrainingSampleType]):
     r"""Base class for gflownets that explicitly uses $P_F$.
 
     Attributes:
@@ -75,9 +75,7 @@ class PFBasedGFlowNet(GFlowNet, Generic[TrainingSampleType]):
         return trajectories
 
 
-class TrajectoryBasedGFlowNet(
-    PFBasedGFlowNet[Trajectories], Generic[TrainingSampleType]
-):
+class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):
     def get_pfs_and_pbs(
         self,
         trajectories: Trajectories,


### PR DESCRIPTION
This PR is an alteration to the fix shipped in #139. While we should still iterate on and decide on whether or not this generic type parameter adds more value than it detracts, this change is a minimal diff which aims to at least gets `master` in a better state.

### `PFBasedGFlowNet`

Originally we had:

```py
class PFBasedGFlowNet(GFlowNet)
```

Which was causing an error because `PFBasedGFlowNet` didn't define the generic parameter for the sample type.

This was updated to:

```py
class PFBasedGFlowNet(GFlowNet, Generic[TrainingSampleType]):
```

But it should be instead:

```py
class PFBasedGFlowNet(GFlowNet[TrainingSampleType]):
```

This is basically saying that `PFBasedGFlowNet` is a kind of `GFlowNet` where the `TrainingSampleType` is not yet known.

### `TrajectoryBasedGFlowNet`

`TrajectoryBasedGFlowNet` didn't need to be changed so this change reverts that part of #139 so that the signature is back to:

```py
class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):
```

This implies that `TrajectoryBasedGFlowNet` is a kind of `PFBasedGFlowNet` which uses `Trajectories` as the sample type.