### PR TITLE
turn off replay buffer while we determine issue with off policy sampling

### DIFF
--- a/tutorials/examples/train_hypergrid.py
+++ b/tutorials/examples/train_hypergrid.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--replay_buffer_size",
         type=int,
-        default=100,
+        default=0,
         help="If zero, no replay buffer is used. Otherwise, the replay buffer is used.",
     )
 


### PR DESCRIPTION
this turns off the replay buffer for `train_hypergrid` while we figure out which bug is causing the issue with off policyness when using a replay buffer.