### PR TITLE
Scalar estimators allow for the reduction over many output values (i.…

### DIFF
--- a/src/gfn/gflownet/flow_matching.py
+++ b/src/gfn/gflownet/flow_matching.py
@@ -203,9 +203,7 @@ class FMGFlowNet(GFlowNet[Tuple[DiscreteStates, DiscreteStates]]):
         )
         return fm_loss + self.alpha * rm_loss
 
-    def to_training_samples(
-        self, trajectories: Trajectories
-    ) -> Union[
+    def to_training_samples(self, trajectories: Trajectories) -> Union[
         Tuple[DiscreteStates, DiscreteStates, torch.Tensor, torch.Tensor],
         Tuple[DiscreteStates, DiscreteStates, None, None],
         Tuple[States, States, torch.Tensor, torch.Tensor],

--- a/src/gfn/gflownet/flow_matching.py
+++ b/src/gfn/gflownet/flow_matching.py
@@ -203,7 +203,9 @@ class FMGFlowNet(GFlowNet[Tuple[DiscreteStates, DiscreteStates]]):
         )
         return fm_loss + self.alpha * rm_loss
 
-    def to_training_samples(self, trajectories: Trajectories) -> Union[
+    def to_training_samples(
+        self, trajectories: Trajectories
+    ) -> Union[
         Tuple[DiscreteStates, DiscreteStates, torch.Tensor, torch.Tensor],
         Tuple[DiscreteStates, DiscreteStates, None, None],
         Tuple[States, States, torch.Tensor, torch.Tensor],

--- a/src/gfn/modules.py
+++ b/src/gfn/modules.py
@@ -9,7 +9,6 @@ from gfn.preprocessors import IdentityPreprocessor, Preprocessor
 from gfn.states import DiscreteStates, States
 from gfn.utils.distributions import UnsqueezedCategorical
 
-
 REDUCTION_FXNS = {
     "mean": torch.mean,
     "sum": torch.sum,

--- a/src/gfn/modules.py
+++ b/src/gfn/modules.py
@@ -142,7 +142,7 @@ class GFNModule(ABC, nn.Module):
 
 
 class ScalarEstimator(GFNModule):
-    r"""Class for estimating scalars such as LogZ.
+    r"""Class for estimating scalars such as LogZ or state flow functions of DB/SubTB.
 
     Training a GFlowNet requires sometimes requires the estimation of precise scalar
     values, such as the partition function of flows on the DAG. This Estimator is
@@ -371,7 +371,7 @@ class ConditionalDiscretePolicyEstimator(DiscretePolicyEstimator):
 
 
 class ConditionalScalarEstimator(ConditionalDiscretePolicyEstimator):
-    r"""Class for conditionally estimating scalars such as LogZ.
+    r"""Class for conditionally estimating scalars (LogZ,  DB/SubTB state logF).
 
     Training a GFlowNet requires sometimes requires the estimation of precise scalar
     values, such as the partition function of flows on the DAG. In the case of a

--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -35,7 +35,11 @@ class Sampler:
         save_estimator_outputs: bool = False,
         save_logprobs: bool = True,
         **policy_kwargs: Any,
-    ) -> Tuple[Actions, torch.Tensor | None, torch.Tensor | None,]:
+    ) -> Tuple[
+        Actions,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
         """Samples actions from the given states.
 
         Args:

--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -35,11 +35,7 @@ class Sampler:
         save_estimator_outputs: bool = False,
         save_logprobs: bool = True,
         **policy_kwargs: Any,
-    ) -> Tuple[
-        Actions,
-        torch.Tensor | None,
-        torch.Tensor | None,
-    ]:
+    ) -> Tuple[Actions, torch.Tensor | None, torch.Tensor | None]:
         """Samples actions from the given states.
 
         Args:


### PR DESCRIPTION
…e., the output of the nn.Module does not need to be a scalar, because the Estimator will apply a reduction to the final output if required).

I am not in love with the current code organization of `modules.py` -- there is some duplication, but I am thinking that a bigger refactoring effort might be en route and perhaps we should wait to optimize. Open to feedback on this!