### PR TITLE
Make CI running in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Python package
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,10 @@
 # This GitHub Action assumes that the repo contains a valid .pre-commit-config.yaml file.
 ---
 name: pre-commit
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,9 @@
 name: Python Package using Conda
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build-linux:


### PR DESCRIPTION
Following this comment: https://github.com/GFNOrg/torchgfn/pull/210#pullrequestreview-2544856088
I like the CI to run on PR, so the reviewer can see it immediately, without need to open the branch.

