### PR TITLE
Standardize recalculate_all_logprobs parameter across PF-based GFlowNets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,4 @@ repos:
         language: python
         files: testing/
         types: [python]
-        always_run: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,9 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry: pytest testing/
-        language: python
+        entry:  /Users/salem.lahlou/miniconda3/envs/gfn2/bin/pytest testing
+        language: system # python
         files: testing/
         types: [python]
         always_run: true
+        

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,8 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry:  /Users/salem.lahlou/miniconda3/envs/gfn2/bin/pytest testing
-        language: system # python
+        entry:  pytest
+        language: python
         files: testing/
         types: [python]
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry:  pytest
+        entry: pytest
         language: python
         files: testing/
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,9 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry: pytest
+        entry: bash -c 'cd testing && pytest'
         language: python
         files: testing/
         types: [python]
         always_run: true
+        args: ["-v", "--tb=short"]  # Add verbose output and shorter tracebacks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,8 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry: bash -c 'cd testing && pytest'
+        entry: pytest testing/
         language: python
         files: testing/
         types: [python]
         always_run: true
-        args: ["-v", "--tb=short"]  # Add verbose output and shorter tracebacks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,4 +48,3 @@ repos:
         files: testing/
         types: [python]
         always_run: true
-        

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,4 @@ repos:
         language: python
         files: testing/
         types: [python]
-        always_run: true
+        always_run: false

--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -71,7 +71,7 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
         """Converts trajectories to training samples. The type depends on the GFlowNet."""
 
     @abstractmethod
-    def loss(self, env: Env, training_objects: Any, **kwargs: Any):
+    def loss(self, env: Env, training_objects: Any):
         """Computes the loss given the training objects."""
 
 
@@ -113,11 +113,7 @@ class PFBasedGFlowNet(GFlowNet[TrainingSampleType], ABC):
 
     @abstractmethod
     def loss(
-        self,
-        env: Env,
-        training_objects: Any,
-        recalculate_all_logprobs: bool = False,
-        **kwargs: Any,
+        self, env: Env, training_objects: Any, recalculate_all_logprobs: bool = False
     ):
         """Computes the loss given the training objects.
 

--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -71,17 +71,12 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
         """Converts trajectories to training samples. The type depends on the GFlowNet."""
 
     @abstractmethod
-    def loss(self, env: Env, training_objects: Any):
+    def loss(self, env: Env, training_objects: Any, **kwargs: Any):
         """Computes the loss given the training objects."""
 
 
-class PFBasedGFlowNet(GFlowNet[TrainingSampleType]):
-    r"""Base class for gflownets that explicitly uses $P_F$.
-
-    Attributes:
-        pf: GFNModule
-        pb: GFNModule
-    """
+class PFBasedGFlowNet(GFlowNet[TrainingSampleType], ABC):
+    """A GFlowNet that uses forward (PF) and backward (PB) policy networks."""
 
     def __init__(self, pf: GFNModule, pb: GFNModule):
         super().__init__()
@@ -115,6 +110,24 @@ class PFBasedGFlowNet(GFlowNet[TrainingSampleType]):
 
     def pf_pb_parameters(self):
         return [v for k, v in self.named_parameters() if "pb" in k or "pf" in k]
+
+    @abstractmethod
+    def loss(
+        self,
+        env: Env,
+        training_objects: Any,
+        recalculate_all_logprobs: bool = False,
+        **kwargs: Any,
+    ):
+        """Computes the loss given the training objects.
+
+        Args:
+            env: The environment to compute the loss for
+            training_objects: The objects to compute the loss on
+            recalculate_all_logprobs: If True, always recalculate logprobs even if they exist.
+                                     If False, use existing logprobs when available.
+            **kwargs: Additional arguments specific to the loss
+        """
 
 
 class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):

--- a/src/gfn/gflownet/detailed_balance.py
+++ b/src/gfn/gflownet/detailed_balance.py
@@ -280,9 +280,13 @@ class ModifiedDBGFlowNet(PFBasedGFlowNet[Transitions]):
 
         return scores
 
-    def loss(self, env: Env, transitions: Transitions) -> torch.Tensor:
+    def loss(
+        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = False
+    ) -> torch.Tensor:
         """Calculates the modified detailed balance loss."""
-        scores = self.get_scores(transitions)
+        scores = self.get_scores(
+            transitions, recalculate_all_logprobs=recalculate_all_logprobs
+        )
         return torch.mean(scores**2)
 
     def to_training_samples(self, trajectories: Trajectories) -> Transitions:

--- a/src/gfn/gflownet/sub_trajectory_balance.py
+++ b/src/gfn/gflownet/sub_trajectory_balance.py
@@ -273,7 +273,10 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
         return full_mask, sink_states_mask, is_terminal_mask
 
     def get_scores(
-        self, env: Env, trajectories: Trajectories
+        self,
+        env: Env,
+        trajectories: Trajectories,
+        recalculate_all_logprobs: bool = False,
     ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
         """Scores all submitted trajectories.
 
@@ -290,7 +293,9 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
                 True if the corresponding sub-trajectory does not exist.
         """
         log_pf_trajectories, log_pb_trajectories = self.get_pfs_and_pbs(
-            trajectories, fill_value=-float("inf")
+            trajectories,
+            fill_value=-float("inf"),
+            recalculate_all_logprobs=recalculate_all_logprobs,
         )
 
         log_pf_trajectories_cum = self.cumulative_logprobs(
@@ -493,9 +498,16 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
 
         return contributions
 
-    def loss(self, env: Env, trajectories: Trajectories) -> torch.Tensor:
+    def loss(
+        self,
+        env: Env,
+        trajectories: Trajectories,
+        recalculate_all_logprobs: bool = False,
+    ) -> torch.Tensor:
         # Get all scores and masks from the trajectories.
-        scores, flattening_masks = self.get_scores(env, trajectories)
+        scores, flattening_masks = self.get_scores(
+            env, trajectories, recalculate_all_logprobs=recalculate_all_logprobs
+        )
         flattening_mask = torch.cat(flattening_masks)
         all_scores = torch.cat(scores, 0)
 


### PR DESCRIPTION
This PR standardizes the handling of `recalculate_all_logprobs` parameter across all policy-based GFlowNet implementations (TB, DB, SubTB).

Changes:
- Added `recalculate_all_logprobs` parameter to `PFBasedGFlowNet.loss()` abstract method
- Added the parameter to all implementing classes (DB, TB, SubTB)
- Default behavior: use existing logprobs if available (when `recalculate_all_logprobs=False`)
- When `recalculate_all_logprobs=True`, force recalculation of logprobs even if they exist

This change:
- Makes behavior consistent across all PF-based GFlowNets
- Aligns with default sampling behavior where `save_logprobs=False` (introduced in #230)
- Removes special case handling in training loops where TBGFlowNet had different behavior than other implementations (identified in #224)
- Does not affect Flow Matching implementation which doesn't use logprobs

Context:
- #230 introduced `save_logprobs=False` as default during sampling to improve memory efficiency
- #224 highlighted inconsistency where only TBGFlowNet accepted `recalculate_all_logprobs` parameter
- This PR unifies the behavior: by default, use existing logprobs if they were saved, otherwise recalculate them
