### PR TITLE
Fix PrioritizedReplayBuffer filtering

### DIFF
--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -206,6 +206,10 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             #         dim=-1,
             #     )
 
+            # If all trajectories were filtered, stop there.
+            if not len(training_objects):
+                return
+
             if self.cutoff_distance >= 0:
                 # Filter the batch for diverse final_states with high reward.
                 batch = training_objects.last_states.tensor.float()


### PR DESCRIPTION
Fix error where add() crashes if no trajectory is better than buffer trajectories.

Specifically, the following lines gave results which couldn't be handled because the Trajectories object was empty:
```python
                batch = training_objects.last_states.tensor.float()
                batch_dim = training_objects.last_states.batch_shape[0]
                try:
                    batch_batch_dist = torch.cdist(
                        batch.view(batch_dim, -1).unsqueeze(0),
                        batch.view(batch_dim, -1).unsqueeze(0),
                        p=self.p_norm_distance,
                    ).squeeze(0)
```
Fix is trivial: flow control out of the function if no trajectories should be added to the buffer.