### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,15 @@
 requires = ["poetry-core>=1.0.8"]
 build-backend = "poetry.core.masonry.api"
 
+[project]
+name = "torchgfn"
 
 [tool.poetry]
 name = "torchgfn"
 packages = [{include = "gfn", from = "src"}]
 version = "1.1.1"
 description = "A torch implementation of GFlowNets"
-authors = ["Salem Lahou <salemlahlou9@gmail.com>", "Joseph Viviano <joseph@viviano.ca>", "Victor Schmidt <vsch@pm.me>"]
+authors = ["Salem Lahlou <salemlahlou9@gmail.com>", "Joseph Viviano <joseph@viviano.ca>", "Victor Schmidt <vsch@pm.me>"]
 license = "MIT"
 readme = "README.md"
 classifiers = [
@@ -16,6 +18,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+
 
 [tool.poetry.dependencies]
 # core dependencies.


### PR DESCRIPTION
Context: I tried building from source with poetry, but kept getting the following error:
```
× Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "/Users/quoding/.pyenv/versions/3.12.2/envs/tests/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/Users/quoding/.pyenv/versions/3.12.2/envs/tests/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/quoding/.pyenv/versions/3.12.2/envs/tests/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 209, in prepare_metadata_for_build_editable
          return hook(metadata_directory, config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/b0/v5gv_vhn7jn281h_3m7rfj1c0000gn/T/pip-build-env-gd5ccoqe/overlay/lib/python3.12/site-packages/poetry/core/masonry/api.py", line 42, in prepare_metadata_for_build_wheel
          poetry = Factory().create_poetry(Path().resolve(), with_groups=False)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/b0/v5gv_vhn7jn281h_3m7rfj1c0000gn/T/pip-build-env-gd5ccoqe/overlay/lib/python3.12/site-packages/poetry/core/factory.py", line 59, in create_poetry
          raise RuntimeError("The Poetry configuration is invalid:\n" + message)
      RuntimeError: The Poetry configuration is invalid:
        - project must contain ['name'] properties
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```
Turns out, the `pyproject.toml` was missing a block and a key.

This commit does the following:
- Add `[project]` block with `name`, following [poetry's documentation](https://python-poetry.org/docs/pyproject/). This is necessary to build because `projects.urls`, is used. Otherwise, an error is thrown.
- Fix Salem's name as author