### PR TITLE
add test for to_transition and some refactorings

### DIFF
--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -360,9 +360,7 @@ class LocalSearchSampler(Sampler):
         # This is called `prev_trajectories` since they are the trajectories before
         # the local search. The `new_trajectories` will be obtained by performing local
         # search on them.
-        prev_trajectories = Trajectories.reverse_backward_trajectories(
-            prev_trajectories
-        )
+        prev_trajectories = prev_trajectories.reverse_backward_trajectories()
         assert prev_trajectories.log_rewards is not None
 
         ### Reconstructing with self.estimator

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -371,8 +371,8 @@ class DiscreteStates(States, ABC):
         backward_masks = self.backward_masks[index]
         out = self.__class__(states, forward_masks, backward_masks)
         if self._log_rewards is not None:
-            log_probs = self._log_rewards[index]
-            out.log_rewards = log_probs
+            log_rewards = self._log_rewards[index]
+            out.log_rewards = log_rewards
         return out
 
     def __setitem__(


### PR DESCRIPTION
Resolve #113 

- Tests added for `to_transition`
- Tests added with continuous environment (Box) for `reverse_backward_trajectories` and `local_search`
- `reverse_backward_trajectories` is changed to a normal method as there seems no reason it should be a staticmethod.