### PR TITLE
Add Append MDP environment (Set Addition) and Perfect Binary Tree environment (bijection traj -> term states)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ scripts.py
 
 models/
 *.DS_Store
+.python-version

--- a/src/gfn/gym/perfect_tree.py
+++ b/src/gfn/gym/perfect_tree.py
@@ -1,0 +1,116 @@
+from typing import Callable
+from gfn.env import Actions, DiscreteEnv, DiscreteStates
+from gfn.gym.helpers.preprocessors import OneHotPreprocessor
+import torch
+
+
+class PerfectTree(DiscreteEnv):
+    r"""
+    Perfect Tree Environment where there is a bijection between trajectories and terminating states.
+    e.g.:
+
+               1
+          /         \
+         2           3
+       /   \       /   \
+      4     5     6     7
+     / \   / \   / \   / \
+    8   9 10 11 12 13 14 15
+
+    """
+
+    def __init__(self, reward_fn: Callable, depth: int = 4, branching_factor: int = 2):
+        self.reward_fn = reward_fn
+        self.depth = depth
+        self.branching_factor = branching_factor
+        self.n_actions = branching_factor + 1
+        self.n_nodes = 2 ** (self.depth + 1) - 1
+
+        self.s0 = torch.zeros((1,), dtype=torch.long)
+        self.sf = torch.full((1,), fill_value=-1, dtype=torch.long)
+        preprocessor = OneHotPreprocessor(self.n_nodes, self.get_states_indices)
+        super().__init__(
+            self.n_actions, self.s0, (1,), preprocessor=preprocessor, sf=self.sf
+        )
+
+        self.transition_table, self.inverse_transition_table, self.term_states = (
+            self._build_tree()
+        )
+
+    def _build_tree(self) -> tuple[dict, dict, DiscreteStates]:
+        """Create a transition table ensuring a bijection between trajectories and last states."""
+        transition_table = {}
+        inverse_transition_table = {}
+        node_index = 0
+        queue = [(node_index, 0)]  # (current_node, depth)
+
+        terminating_states_id = set()
+        while queue:
+            node, d = queue.pop(0)
+            if d < self.depth:
+                for a in range(self.branching_factor):
+                    node_index += 1
+                    transition_table[(node, a)] = node_index
+                    inverse_transition_table[(node_index, a)] = node
+                    queue.append((node_index, d + 1))
+            else:
+                terminating_states_id.add(node)
+        terminating_states_id = torch.tensor(list(terminating_states_id)).reshape(-1, 1)
+        terminating_states = self.states_from_tensor(terminating_states_id)
+
+        return transition_table, inverse_transition_table, terminating_states
+
+    def backward_step(self, states: DiscreteStates, actions: Actions) -> torch.Tensor:
+        tuples = torch.hstack((states.tensor, actions.tensor)).tolist()
+        tuples = tuple((tuple_) for tuple_ in tuples)
+        next_states_tns = [
+            self.inverse_transition_table.get(tuple_) for tuple_ in tuples
+        ]
+        next_states_tns = torch.tensor(next_states_tns).reshape(-1, 1)
+        return next_states_tns
+
+    def step(self, states: DiscreteStates, actions: Actions) -> torch.Tensor:
+        tuples = torch.hstack((states.tensor, actions.tensor)).tolist()
+        tuples = tuple(tuple(tuple_) for tuple_ in tuples)
+        next_states_tns = [self.transition_table.get(tuple_) for tuple_ in tuples]
+        next_states_tns = torch.tensor(next_states_tns).reshape(-1, 1).long()
+        return next_states_tns
+
+    def update_masks(self, states: DiscreteStates) -> None:
+        terminating_states_mask = torch.isin(
+            states.tensor, self.terminating_states.tensor
+        ).flatten()
+        initial_state_mask = (states.tensor == self.s0).flatten()
+        even_states = (states.tensor % 2 == 0).flatten()
+
+        # Going from any node, we can choose action 0 or 1
+        # Except terminating states where we must end the trajectory
+        states.forward_masks[~terminating_states_mask, -1] = False
+        states.forward_masks[terminating_states_mask, :] = False
+        states.forward_masks[terminating_states_mask, -1] = True
+
+        # Even states are to the right, so tied to action 1
+        # Uneven states are to the left, tied to action 0
+        states.backward_masks[even_states, 1] = True
+        states.backward_masks[even_states, 0] = False
+        states.backward_masks[~even_states, 1] = False
+        states.backward_masks[~even_states, 0] = True
+
+        # Initial state has no available backward action
+        states.backward_masks[initial_state_mask, :] = False
+
+    def get_states_indices(self, states: DiscreteStates):
+        return torch.flatten(states.tensor)
+
+    @property
+    def all_states(self) -> DiscreteStates:
+        return self.states_from_tensor(torch.arange(self.n_nodes).reshape(-1, 1))
+
+    @property
+    def terminating_states(self) -> DiscreteStates:
+        lb = 2**self.depth - 1
+        ub = 2 ** (self.depth + 1) - 1
+        return self.make_states_class()(torch.arange(lb, ub).reshape(-1, 1))
+
+    def reward(self, final_states):
+        return self.reward_fn(final_states.tensor)

--- a/src/gfn/gym/set_addition.py
+++ b/src/gfn/gym/set_addition.py
@@ -1,0 +1,70 @@
+from typing import Callable
+from gfn.env import Actions, DiscreteEnv, DiscreteStates
+import torch
+
+
+class SetAddition(DiscreteEnv):
+    """Append only MDP, similarly to what is described in Remark 8 of Shen et al. 2023
+    [Towards Understanding and Improving GFlowNet Training](https://proceedings.mlr.press/v202/shen23a.html)
+    """
+
+    def __init__(self, n_items: int, max_items: int, reward_fn: Callable):
+        self.n_items = n_items
+        self.reward_fn = reward_fn
+        self.max_traj_len = max_items
+        n_actions = n_items + 1
+        s0 = torch.zeros(n_items)
+        state_shape = (n_items,)
+
+        super().__init__(n_actions, s0, state_shape)
+
+    def get_states_indices(self, states: DiscreteStates):
+        states_raw = states.tensor
+
+        canonical_base = 2 ** torch.arange(
+            self.n_items - 1, -1, -1, device=states_raw.device
+        )
+        indices = (canonical_base * states_raw).sum(-1).long()
+        return indices
+
+    def update_masks(self, states: DiscreteStates) -> None:
+        trajs_that_must_end = states.tensor.sum(dim=1) >= self.max_traj_len
+        trajs_that_may_continue = states.tensor.sum(dim=1) < self.max_traj_len
+
+        states.forward_masks[trajs_that_may_continue, : self.n_items] = (
+            states.tensor[trajs_that_may_continue] == 0
+        )
+
+        # Disallow everything for trajs that must end
+        states.forward_masks[trajs_that_must_end, : self.n_items] = 0
+        states.forward_masks[..., -1] = 1  # Allow exit action
+
+        states.backward_masks[..., : self.n_items] = states.tensor != 0
+
+        # Disallow exit action if at s_0
+        at_initial_state = torch.all(states.tensor == 0, dim=1)
+        states.forward_masks[at_initial_state, -1] = 0
+
+    def step(self, states: DiscreteStates, actions: Actions) -> torch.Tensor:
+        new_states_tensor = states.tensor.scatter(-1, actions.tensor, 1, reduce="add")
+        return new_states_tensor
+
+    def backward_step(self, states: DiscreteStates, actions: Actions):
+        new_states_tensor = states.tensor.scatter(-1, actions.tensor, -1, reduce="add")
+        return new_states_tensor
+
+    def get_reward(self, final_states: DiscreteStates) -> torch.Tensor:
+        return self.reward_fn(final_states.tensor)
+
+    def log_reward(self, final_states: DiscreteStates) -> torch.Tensor:
+        return torch.log(self.get_reward(final_states))
+
+    @property
+    def all_states(self) -> DiscreteStates:
+        digits = torch.arange(0, 2, device=self.device)
+        all_states = torch.cartesian_prod(*[digits] * self.n_items)
+        return DiscreteStates(all_states)
+
+    @property
+    def terminating_states(self) -> DiscreteStates:
+        return self.all_states[1:]  # Remove initial state s_0


### PR DESCRIPTION
Hi,

I have implemented two simple gym environments which I find useful when experimenting with GFNs.

First one is simply an append MDP where there is a set of items, and any item can be added to the set at any time. Exit is allowed at any time except at the initial state. An instance may look like the following MDP (without the terminal state to lighten the figure).

<img width="311" alt="image" src="https://github.com/user-attachments/assets/b0634dfa-c530-4c4a-b288-80afbf028f83" />

The second environment is a [Perfect Binary Tree](https://en.wikipedia.org/wiki/Binary_tree#Types_of_binary_trees) MDP, where there is a bijection between trajectories and terminating states. Action 0 goes left, action 1 goes right. One could easily extend this environment to non-binary trees. We can discuss if it is necessary or interesting for torchgfn to have a non-binary extension environments. An instance of Perfect Binary Tree may look like:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/29329708-a8e9-445b-8a92-0e3020cf5285" />

