### PR TITLE
Handle recalculate_all_logprobs consistently across the library, and throw warnings where appropriate

### DIFF
--- a/src/gfn/containers/__init__.py
+++ b/src/gfn/containers/__init__.py
@@ -1,4 +1,4 @@
-from .base import Container, has_log_probs
+from .base import Container
 from .replay_buffer import NormBasedDiversePrioritizedReplayBuffer, ReplayBuffer
 from .state_pairs import StatePairs
 from .trajectories import Trajectories
@@ -11,5 +11,4 @@ __all__ = [
     "Trajectories",
     "Transitions",
     "Container",
-    "has_log_probs",
 ]

--- a/src/gfn/containers/__init__.py
+++ b/src/gfn/containers/__init__.py
@@ -1,4 +1,4 @@
-from .base import Container
+from .base import Container, has_log_probs
 from .replay_buffer import NormBasedDiversePrioritizedReplayBuffer, ReplayBuffer
 from .state_pairs import StatePairs
 from .trajectories import Trajectories
@@ -11,4 +11,5 @@ __all__ = [
     "Trajectories",
     "Transitions",
     "Container",
+    "has_log_probs",
 ]

--- a/src/gfn/containers/base.py
+++ b/src/gfn/containers/base.py
@@ -55,10 +55,10 @@ class Container(ABC):
             else:
                 raise ValueError(f"Unexpected {key} of type {type(val)}")
 
+    @property
+    def has_log_probs(self) -> bool:
+        """Returns True if the container has the log_probs attribute populated."""
+        if not hasattr(self, "log_probs"):
+            return False
 
-def has_log_probs(obj: Container):
-    """Returns True if the submitted container has the log_probs attribute populated."""
-    if not hasattr(obj, "log_probs"):
-        return False
-
-    return obj.log_probs is not None and obj.log_probs.nelement() > 0
+        return self.log_probs is not None and self.log_probs.nelement() > 0

--- a/src/gfn/containers/base.py
+++ b/src/gfn/containers/base.py
@@ -54,3 +54,11 @@ class Container(ABC):
                 self.__dict__[key] = torch.load(os.path.join(path, key + ".pt"))
             else:
                 raise ValueError(f"Unexpected {key} of type {type(val)}")
+
+
+def has_log_probs(obj: Container):
+    """Returns True if the submitted container has the log_probs attribute populated."""
+    if not hasattr(obj, "log_probs"):
+        return False
+
+    return obj.log_probs is not None and obj.log_probs.nelement() > 0

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -5,12 +5,11 @@ from typing import Sequence
 import torch
 
 from gfn.actions import Actions
-from gfn.containers.base import Container
+from gfn.containers.base import Container, has_log_probs
 from gfn.containers.state_pairs import StatePairs
 from gfn.containers.transitions import Transitions
 from gfn.env import Env
 from gfn.states import DiscreteStates, States
-from gfn.utils.common import has_log_probs
 
 
 # TODO: remove env from this class?

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -5,7 +5,7 @@ from typing import Sequence
 import torch
 
 from gfn.actions import Actions
-from gfn.containers.base import Container, has_log_probs
+from gfn.containers.base import Container
 from gfn.containers.state_pairs import StatePairs
 from gfn.containers.transitions import Transitions
 from gfn.env import Env
@@ -382,7 +382,7 @@ class Trajectories(Container):
             )
 
         # Initialize log_probs None if not available
-        if has_log_probs(self):
+        if self.has_log_probs:
             log_probs = self.log_probs[~self.actions.is_dummy]
         else:
             log_probs = None

--- a/src/gfn/containers/transitions.py
+++ b/src/gfn/containers/transitions.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from gfn.env import Env
     from gfn.states import States
 
-from gfn.containers.base import Container, has_log_probs
+from gfn.containers.base import Container
 
 
 class Transitions(Container):
@@ -213,7 +213,7 @@ class Transitions(Container):
         log_rewards = self._log_rewards[index] if self._log_rewards is not None else None
 
         # Only return logprobs if they exist.
-        log_probs = self.log_probs[index] if has_log_probs(self) else None
+        log_probs = self.log_probs[index] if self.has_log_probs else None
 
         return Transitions(
             env=self.env,

--- a/src/gfn/containers/transitions.py
+++ b/src/gfn/containers/transitions.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:
     from gfn.env import Env
     from gfn.states import States
 
-from gfn.containers.base import Container
-from gfn.utils.common import has_log_probs
+from gfn.containers.base import Container, has_log_probs
 
 
 class Transitions(Container):

--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -10,7 +10,6 @@ from gfn.env import Env
 from gfn.modules import GFNModule
 from gfn.samplers import Sampler
 from gfn.states import States
-from gfn.utils.handlers import warn_about_recalculating_logprobs
 from gfn.utils.prob_calculations import get_trajectory_pfs_and_pbs
 
 TrainingSampleType = TypeVar("TrainingSampleType", bound=Container)
@@ -103,7 +102,6 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
             torch.Tensor: The computed loss
         """
         training_samples = self.to_training_samples(trajectories)
-        warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
 
         return self.loss(
             env,

--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -97,6 +97,8 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
         Args:
             env: The environment to compute the loss for
             trajectories: The trajectories to compute the loss from
+            recalculate_all_logprobs: If True, always recalculate logprobs even
+                if they exist. If False, use existing logprobs when available.
 
         Returns:
             torch.Tensor: The computed loss

--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -1,5 +1,4 @@
 import math
-import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Tuple, TypeVar
 
@@ -11,7 +10,7 @@ from gfn.env import Env
 from gfn.modules import GFNModule
 from gfn.samplers import Sampler
 from gfn.states import States
-from gfn.utils.common import has_log_probs
+from gfn.utils.handlers import warn_about_recalculating_logprobs
 from gfn.utils.prob_calculations import get_trajectory_pfs_and_pbs
 
 TrainingSampleType = TypeVar("TrainingSampleType", bound=Container)
@@ -70,11 +69,26 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
         """Converts trajectories to training samples. The type depends on the GFlowNet."""
 
     @abstractmethod
-    def loss(self, env: Env, training_objects: Any) -> torch.Tensor:
-        """Computes the loss given the training objects."""
+    def loss(
+        self,
+        env: Env,
+        training_objects: Any,
+        recalculate_all_logprobs: bool = True,
+    ) -> torch.Tensor:
+        """Computes the loss given the training objects.
+
+        Args:
+            env: The environment to compute the loss for
+            training_objects: The objects to compute the loss on
+            recalculate_all_logprobs: If True, always recalculate logprobs even
+                if they exist. If False, use existing logprobs when available.
+        """
 
     def loss_from_trajectories(
-        self, env: Env, trajectories: Trajectories
+        self,
+        env: Env,
+        trajectories: Trajectories,
+        recalculate_all_logprobs: bool = True,
     ) -> torch.Tensor:
         """Helper method to compute loss directly from trajectories.
 
@@ -89,18 +103,13 @@ class GFlowNet(ABC, nn.Module, Generic[TrainingSampleType]):
             torch.Tensor: The computed loss
         """
         training_samples = self.to_training_samples(trajectories)
-        if isinstance(self, PFBasedGFlowNet):
-            # Check if trajectories already have log_probs
-            if has_log_probs(trajectories):
-                warnings.warn(
-                    "Recalculating logprobs for trajectories that already have them. "
-                    "This may be inefficient for on-policy trajectories. "
-                    "If the training is done on-policy, you should call loss() directly with recalculate_all_logprobs=False instead of loss_from_trajectories()."
-                )
+        warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
 
-            # We know this is safe because PFBasedGFlowNet's loss accepts these arguments
-            return self.loss(env, training_samples, recalculate_all_logprobs=True)
-        return self.loss(env, training_samples)
+        return self.loss(
+            env,
+            training_samples,
+            recalculate_all_logprobs=recalculate_all_logprobs,
+        )
 
 
 class PFBasedGFlowNet(GFlowNet[TrainingSampleType], ABC):
@@ -139,27 +148,13 @@ class PFBasedGFlowNet(GFlowNet[TrainingSampleType], ABC):
     def pf_pb_parameters(self):
         return [v for k, v in self.named_parameters() if "pb" in k or "pf" in k]
 
-    @abstractmethod
-    def loss(
-        self, env: Env, training_objects: Any, recalculate_all_logprobs: bool = False
-    ) -> torch.Tensor:
-        """Computes the loss given the training objects.
-
-        Args:
-            env: The environment to compute the loss for
-            training_objects: The objects to compute the loss on
-            recalculate_all_logprobs: If True, always recalculate logprobs even if they exist.
-                                     If False, use existing logprobs when available.
-            **kwargs: Additional arguments specific to the loss
-        """
-
 
 class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):
     def get_pfs_and_pbs(
         self,
         trajectories: Trajectories,
         fill_value: float = 0.0,
-        recalculate_all_logprobs: bool = False,
+        recalculate_all_logprobs: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         r"""Evaluates logprobs for each transition in each trajectory in the batch.
 
@@ -194,7 +189,7 @@ class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):
     def get_trajectories_scores(
         self,
         trajectories: Trajectories,
-        recalculate_all_logprobs: bool = False,
+        recalculate_all_logprobs: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Given a batch of trajectories, calculate forward & backward policy scores.
 

--- a/src/gfn/gflownet/detailed_balance.py
+++ b/src/gfn/gflownet/detailed_balance.py
@@ -3,14 +3,14 @@ from typing import Tuple
 
 import torch
 
-from gfn.containers import Trajectories, Transitions
+from gfn.containers import Trajectories, Transitions, has_log_probs
 from gfn.env import Env
 from gfn.gflownet.base import PFBasedGFlowNet
 from gfn.modules import ConditionalScalarEstimator, GFNModule, ScalarEstimator
-from gfn.utils.common import has_log_probs
 from gfn.utils.handlers import (
     has_conditioning_exception_handler,
     no_conditioning_exception_handler,
+    warn_about_recalculating_logprobs,
 )
 from gfn.utils.prob_calculations import get_transition_pfs_and_pbs
 
@@ -80,14 +80,14 @@ class DBGFlowNet(PFBasedGFlowNet[Transitions]):
             )
 
     def get_pfs_and_pbs(
-        self, transitions: Transitions, recalculate_all_logprobs: bool = False
+        self, transitions: Transitions, recalculate_all_logprobs: bool = True
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return get_transition_pfs_and_pbs(
             self.pf, self.pb, transitions, recalculate_all_logprobs
         )
 
     def get_scores(
-        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = False
+        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = True
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Given a batch of transitions, calculate the scores.
 
@@ -173,12 +173,14 @@ class DBGFlowNet(PFBasedGFlowNet[Transitions]):
         return log_pf_actions, log_pb_actions, scores
 
     def loss(
-        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = False
+        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = True
     ) -> torch.Tensor:
         """Detailed balance loss.
 
         The detailed balance loss is described in section
-        3.2 of [GFlowNet Foundations](https://arxiv.org/abs/2111.09266)."""
+        3.2 of [GFlowNet Foundations](https://arxiv.org/abs/2111.09266).
+        """
+        warn_about_recalculating_logprobs(transitions, recalculate_all_logprobs)
         _, _, scores = self.get_scores(env, transitions, recalculate_all_logprobs)
         loss = torch.mean(scores**2)
 
@@ -200,7 +202,7 @@ class ModifiedDBGFlowNet(PFBasedGFlowNet[Transitions]):
     """
 
     def get_scores(
-        self, transitions: Transitions, recalculate_all_logprobs: bool = False
+        self, transitions: Transitions, recalculate_all_logprobs: bool = True
     ) -> torch.Tensor:
         """DAG-GFN-style detailed balance, when all states are connected to the sink.
 
@@ -285,9 +287,10 @@ class ModifiedDBGFlowNet(PFBasedGFlowNet[Transitions]):
         return scores
 
     def loss(
-        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = False
+        self, env: Env, transitions: Transitions, recalculate_all_logprobs: bool = True
     ) -> torch.Tensor:
         """Calculates the modified detailed balance loss."""
+        warn_about_recalculating_logprobs(transitions, recalculate_all_logprobs)
         scores = self.get_scores(
             transitions, recalculate_all_logprobs=recalculate_all_logprobs
         )

--- a/src/gfn/gflownet/detailed_balance.py
+++ b/src/gfn/gflownet/detailed_balance.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import torch
 
-from gfn.containers import Trajectories, Transitions, has_log_probs
+from gfn.containers import Trajectories, Transitions
 from gfn.env import Env
 from gfn.gflownet.base import PFBasedGFlowNet
 from gfn.modules import ConditionalScalarEstimator, GFNModule, ScalarEstimator
@@ -236,7 +236,7 @@ class ModifiedDBGFlowNet(PFBasedGFlowNet[Transitions]):
 
         pf_dist = self.pf.to_probability_distribution(states, module_output)
 
-        if has_log_probs(transitions) and not recalculate_all_logprobs:
+        if transitions.has_log_probs and not recalculate_all_logprobs:
             valid_log_pf_actions = transitions[mask].log_probs
         else:
             # Evaluate the log PF of the actions sampled off policy.

--- a/src/gfn/gflownet/flow_matching.py
+++ b/src/gfn/gflownet/flow_matching.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 import torch
@@ -12,6 +13,8 @@ from gfn.utils.handlers import (
     has_conditioning_exception_handler,
     no_conditioning_exception_handler,
 )
+
+warnings.filterwarnings("once", message="recalculate_all_logprobs is not used for FM.*")
 
 
 class FMGFlowNet(GFlowNet[StatePairs[DiscreteStates]]):
@@ -178,14 +181,22 @@ class FMGFlowNet(GFlowNet[StatePairs[DiscreteStates]]):
         self,
         env: DiscreteEnv,
         state_pairs: StatePairs[DiscreteStates],
+        recalculate_all_logprobs: bool = True,
     ) -> torch.Tensor:
         """Given a batch of non-terminal and terminal states, compute a loss.
 
         Unlike the GFlowNets Foundations paper, we allow more flexibility by passing a
         StatePairs container that holds both the internal states of the trajectories
-        (i.e. non-terminal states) and the terminal states."""
+        (i.e. non-terminal states) and the terminal states.
+        """
         assert isinstance(state_pairs.intermediary_states, DiscreteStates)
         assert isinstance(state_pairs.terminating_states, DiscreteStates)
+        if recalculate_all_logprobs:
+            warnings.warn(
+                "recalculate_all_logprobs is not used for FM. " "Ignoring the argument."
+            )
+        del recalculate_all_logprobs  # Unused for FM.
+
         fm_loss = self.flow_matching_loss(
             env, state_pairs.intermediary_states, state_pairs.intermediary_conditioning
         )

--- a/src/gfn/gflownet/sub_trajectory_balance.py
+++ b/src/gfn/gflownet/sub_trajectory_balance.py
@@ -10,6 +10,7 @@ from gfn.modules import ConditionalScalarEstimator, GFNModule, ScalarEstimator
 from gfn.utils.handlers import (
     has_conditioning_exception_handler,
     no_conditioning_exception_handler,
+    warn_about_recalculating_logprobs,
 )
 
 ContributionsTensor = (
@@ -276,7 +277,7 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
         self,
         env: Env,
         trajectories: Trajectories,
-        recalculate_all_logprobs: bool = False,
+        recalculate_all_logprobs: bool = True,
     ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
         """Scores all submitted trajectories.
 
@@ -502,8 +503,9 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
         self,
         env: Env,
         trajectories: Trajectories,
-        recalculate_all_logprobs: bool = False,
+        recalculate_all_logprobs: bool = True,
     ) -> torch.Tensor:
+        warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
         # Get all scores and masks from the trajectories.
         scores, flattening_masks = self.get_scores(
             env, trajectories, recalculate_all_logprobs=recalculate_all_logprobs

--- a/src/gfn/gflownet/trajectory_balance.py
+++ b/src/gfn/gflownet/trajectory_balance.py
@@ -12,7 +12,10 @@ from gfn.containers import Trajectories
 from gfn.env import Env
 from gfn.gflownet.base import TrajectoryBasedGFlowNet
 from gfn.modules import GFNModule, ScalarEstimator
-from gfn.utils.handlers import is_callable_exception_handler
+from gfn.utils.handlers import (
+    is_callable_exception_handler,
+    warn_about_recalculating_logprobs,
+)
 
 
 class TBGFlowNet(TrajectoryBasedGFlowNet):
@@ -52,7 +55,7 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
         self,
         env: Env,
         trajectories: Trajectories,
-        recalculate_all_logprobs: bool = False,
+        recalculate_all_logprobs: bool = True,
     ) -> torch.Tensor:
         """Trajectory balance loss.
 
@@ -63,6 +66,7 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
             ValueError: if the loss is NaN.
         """
         del env  # unused
+        warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
         _, _, scores = self.get_trajectories_scores(
             trajectories, recalculate_all_logprobs=recalculate_all_logprobs
         )
@@ -107,7 +111,7 @@ class LogPartitionVarianceGFlowNet(TrajectoryBasedGFlowNet):
         self,
         env: Env,
         trajectories: Trajectories,
-        recalculate_all_logprobs: bool = False,
+        recalculate_all_logprobs: bool = True,
     ) -> torch.Tensor:
         """Log Partition Variance loss.
 
@@ -115,6 +119,7 @@ class LogPartitionVarianceGFlowNet(TrajectoryBasedGFlowNet):
         [ROBUST SCHEDULING WITH GFLOWNETS](https://arxiv.org/abs/2302.05446))
         """
         del env  # unused
+        warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
         _, _, scores = self.get_trajectories_scores(
             trajectories, recalculate_all_logprobs=recalculate_all_logprobs
         )

--- a/src/gfn/utils/common.py
+++ b/src/gfn/utils/common.py
@@ -18,11 +18,3 @@ def set_seed(seed: int, performance_mode: bool = False) -> None:
     if not performance_mode:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-
-
-def has_log_probs(obj):
-    """Returns True if the submitted object has the log_probs attribute populated."""
-    if not hasattr(obj, "log_probs"):
-        return False
-
-    return obj.log_probs is not None and obj.log_probs.nelement() > 0

--- a/src/gfn/utils/handlers.py
+++ b/src/gfn/utils/handlers.py
@@ -2,7 +2,7 @@ import warnings
 from contextlib import contextmanager
 from typing import Any
 
-from gfn.containers import Container, has_log_probs
+from gfn.containers import Container
 
 
 @contextmanager
@@ -49,10 +49,11 @@ def warn_about_recalculating_logprobs(
     obj: Container,
     recalculate_all_logprobs: bool,
 ):
-    if recalculate_all_logprobs and has_log_probs(obj):
+    if recalculate_all_logprobs and obj.has_log_probs:
         warnings.warn(
             "Recalculating logprobs for a container that already has them. "
-            "This is inefficient when training on-policy.You should instead "
-            "call loss() or loss_from_trajectories() with "
+            "This might be intended, if the log_probs were calculated off-policy."
+            "However, this is inefficient when training on-policy. In this case, "
+            "you should instead call loss() or loss_from_trajectories() with "
             "recalculate_all_logprobs=False "
         )

--- a/src/gfn/utils/handlers.py
+++ b/src/gfn/utils/handlers.py
@@ -1,5 +1,8 @@
+import warnings
 from contextlib import contextmanager
 from typing import Any
+
+from gfn.containers import Container, has_log_probs
 
 
 @contextmanager
@@ -40,3 +43,16 @@ def is_callable_exception_handler(
             f"conditioning was passed but {target_name} is not callable: {type(target)}"
         )
         raise
+
+
+def warn_about_recalculating_logprobs(
+    obj: Container,
+    recalculate_all_logprobs: bool,
+):
+    if recalculate_all_logprobs and has_log_probs(obj):
+        warnings.warn(
+            "Recalculating logprobs for a container that already has them. "
+            "This is inefficient when training on-policy.You should instead "
+            "call loss() or loss_from_trajectories() with "
+            "recalculate_all_logprobs=False "
+        )

--- a/src/gfn/utils/prob_calculations.py
+++ b/src/gfn/utils/prob_calculations.py
@@ -35,7 +35,7 @@ def get_trajectory_pfs_and_pbs(
     pb: GFNModule,
     trajectories: Trajectories,
     fill_value: float = 0.0,
-    recalculate_all_logprobs: bool = False,
+    recalculate_all_logprobs: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     # fill value is the value used for invalid states (sink state usually)
 
@@ -57,7 +57,7 @@ def get_trajectory_pfs(
     pf: GFNModule,
     trajectories: Trajectories,
     fill_value: float = 0.0,
-    recalculate_all_logprobs: bool = False,
+    recalculate_all_logprobs: bool = True,
 ) -> torch.Tensor:
     if trajectories.is_backward:
         raise ValueError("Backward trajectories are not supported")
@@ -179,7 +179,7 @@ def get_transition_pfs_and_pbs(
     pf: GFNModule,
     pb: GFNModule,
     transitions: Transitions,
-    recalculate_all_logprobs: bool = False,
+    recalculate_all_logprobs: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if transitions.is_backward:
         raise ValueError("Backward transitions are not supported")
@@ -194,7 +194,7 @@ def get_transition_pfs_and_pbs(
 
 
 def get_transition_pfs(
-    pf: GFNModule, transitions: Transitions, recalculate_all_logprobs: bool = False
+    pf: GFNModule, transitions: Transitions, recalculate_all_logprobs: bool = True
 ) -> torch.Tensor:
     states = transitions.states
     actions = transitions.actions

--- a/src/gfn/utils/prob_calculations.py
+++ b/src/gfn/utils/prob_calculations.py
@@ -2,10 +2,9 @@ from typing import Tuple
 
 import torch
 
-from gfn.containers import Trajectories, Transitions
+from gfn.containers import Trajectories, Transitions, has_log_probs
 from gfn.modules import GFNModule
 from gfn.states import States
-from gfn.utils.common import has_log_probs
 from gfn.utils.handlers import (
     has_conditioning_exception_handler,
     no_conditioning_exception_handler,

--- a/src/gfn/utils/prob_calculations.py
+++ b/src/gfn/utils/prob_calculations.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import torch
 
-from gfn.containers import Trajectories, Transitions, has_log_probs
+from gfn.containers import Trajectories, Transitions
 from gfn.modules import GFNModule
 from gfn.states import States
 from gfn.utils.handlers import (
@@ -71,7 +71,7 @@ def get_trajectory_pfs(
     if valid_states.batch_shape != tuple(valid_actions.batch_shape):
         raise AssertionError("Something wrong happening with log_pf evaluations")
 
-    if has_log_probs(trajectories) and not recalculate_all_logprobs:
+    if trajectories.has_log_probs and not recalculate_all_logprobs:
         log_pf_trajectories = trajectories.log_probs
     else:
         log_pf_trajectories = torch.full_like(
@@ -198,7 +198,7 @@ def get_transition_pfs(
     states = transitions.states
     actions = transitions.actions
 
-    if has_log_probs(transitions) and not recalculate_all_logprobs:
+    if transitions.has_log_probs and not recalculate_all_logprobs:
         log_pf_actions = transitions.log_probs
     else:
         # Evaluate the log PF of the actions, with optional conditioning.

--- a/testing/test_parametrizations_and_losses.py
+++ b/testing/test_parametrizations_and_losses.py
@@ -63,7 +63,7 @@ def test_FM(env_name: str, ndim: int, module_name: str):
     gflownet = FMGFlowNet(log_F_edge)  # forward looking by default.
     trajectories = gflownet.sample_trajectories(env, n=N, save_logprobs=True)
     states_tuple = trajectories.to_state_pairs()
-    loss = gflownet.loss(env, states_tuple)
+    loss = gflownet.loss(env, states_tuple, recalculate_all_logprobs=False)
     assert loss >= 0
 
 
@@ -84,7 +84,7 @@ def test_get_pfs_and_pbs(
     gflownet_on = TBGFlowNet(pf=pf_estimator, pb=pb_estimator)
     gflownet_off = TBGFlowNet(pf=pf_estimator, pb=pb_estimator)
 
-    _ = gflownet_on.get_pfs_and_pbs(trajectories)
+    _ = gflownet_on.get_pfs_and_pbs(trajectories, recalculate_all_logprobs=False)
     _ = gflownet_off.get_pfs_and_pbs(trajectories, recalculate_all_logprobs=True)
 
 
@@ -104,7 +104,9 @@ def test_get_scores(
     )
     gflownet_on = TBGFlowNet(pf=pf_estimator, pb=pb_estimator)
     gflownet_off = TBGFlowNet(pf=pf_estimator, pb=pb_estimator)
-    scores_on = gflownet_on.get_trajectories_scores(trajectories)
+    scores_on = gflownet_on.get_trajectories_scores(
+        trajectories, recalculate_all_logprobs=False
+    )
     scores_off = gflownet_off.get_trajectories_scores(
         trajectories, recalculate_all_logprobs=True
     )
@@ -245,14 +247,16 @@ def PFBasedGFlowNet_with_return(
     trajectories = gflownet.sample_trajectories(env, n=N, save_logprobs=True)
     training_objects = gflownet.to_training_samples(trajectories)
     gflownet = cast(GFlowNet, gflownet)
-    _ = gflownet.loss(env, training_objects)
+    _ = gflownet.loss(env, training_objects, recalculate_all_logprobs=False)
 
     if isinstance(gflownet, TBGFlowNet):
         assert isinstance(training_objects, Trajectories)
         assert training_objects.log_probs is not None
         assert torch.all(
             torch.abs(
-                gflownet.get_pfs_and_pbs(training_objects)[0]
+                gflownet.get_pfs_and_pbs(
+                    training_objects, recalculate_all_logprobs=False
+                )[0]
                 - training_objects.log_probs
             )
             < 1e-5
@@ -354,11 +358,11 @@ def test_subTB_vs_TB(
     )
 
     trajectories = gflownet.sample_trajectories(env, n=N, save_logprobs=True)
-    subtb_loss = gflownet.loss(env, trajectories)
+    subtb_loss = gflownet.loss(env, trajectories, recalculate_all_logprobs=False)
 
     if weighting == "TB":
         tb_loss = TBGFlowNet(pf=pf, pb=pb).loss(
-            env, trajectories
+            env, trajectories, recalculate_all_logprobs=False
         )  # LogZ is default 0.0.
         assert (tb_loss - subtb_loss).abs() < 1e-4
 

--- a/testing/test_samplers_and_trajectories.py
+++ b/testing/test_samplers_and_trajectories.py
@@ -296,7 +296,9 @@ def test_to_transition(env_name: str):
         bwd_trajectories = Trajectories.reverse_backward_trajectories(bwd_trajectories)
         # evaluate with pf_estimator
         backward_traj_pfs = get_trajectory_pfs(
-            pf=pf_estimator, trajectories=bwd_trajectories
+            pf=pf_estimator,
+            trajectories=bwd_trajectories,
+            recalculate_all_logprobs=False,
         )
         bwd_trajectories.log_probs = backward_traj_pfs
         _ = bwd_trajectories.to_transitions()

--- a/tutorials/examples/test_scripts.py
+++ b/tutorials/examples/test_scripts.py
@@ -8,9 +8,14 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 
-from .train_box import main as train_box_main
-from .train_discreteebm import main as train_discreteebm_main
-from .train_hypergrid import main as train_hypergrid_main
+try:
+    from train_box import main as train_box_main
+    from train_discreteebm import main as train_discreteebm_main
+    from train_hypergrid import main as train_hypergrid_main
+except ImportError:
+    from .train_box import main as train_box_main
+    from .train_discreteebm import main as train_discreteebm_main
+    from .train_hypergrid import main as train_hypergrid_main
 
 
 @dataclass

--- a/tutorials/examples/test_scripts.py
+++ b/tutorials/examples/test_scripts.py
@@ -8,14 +8,9 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 
-try:
-    from train_box import main as train_box_main
-    from train_discreteebm import main as train_discreteebm_main
-    from train_hypergrid import main as train_hypergrid_main
-except ImportError:
-    from .train_box import main as train_box_main
-    from .train_discreteebm import main as train_discreteebm_main
-    from .train_hypergrid import main as train_hypergrid_main
+from .train_box import main as train_box_main
+from .train_discreteebm import main as train_discreteebm_main
+from .train_hypergrid import main as train_hypergrid_main
 
 
 @dataclass

--- a/tutorials/examples/train_box.py
+++ b/tutorials/examples/train_box.py
@@ -252,7 +252,9 @@ def main(args):  # noqa: C901
         )
 
         optimizer.zero_grad()
-        loss = gflownet.loss_from_trajectories(env, trajectories)
+        loss = gflownet.loss_from_trajectories(
+            env, trajectories, recalculate_all_logprobs=False
+        )
         loss.backward()
         for p in gflownet.parameters():
             if p.ndim > 0 and p.grad is not None:  # We do not clip logZ grad.

--- a/tutorials/examples/train_conditional.py
+++ b/tutorials/examples/train_conditional.py
@@ -214,7 +214,9 @@ def train(env, gflownet, seed):
             epsilon=exploration_rate,
         )
         optimizer.zero_grad()
-        loss = gflownet.loss_from_trajectories(env, trajectories)
+        loss = gflownet.loss_from_trajectories(
+            env, trajectories, recalculate_all_logprobs=False
+        )
         loss.backward()
         optimizer.step()
         pbar.set_postfix({"loss": loss.item()})

--- a/tutorials/examples/train_discreteebm.py
+++ b/tutorials/examples/train_discreteebm.py
@@ -76,7 +76,7 @@ def main(args):  # noqa: C901
         )
         training_samples = gflownet.to_training_samples(trajectories)
         optimizer.zero_grad()
-        loss = gflownet.loss(env, training_samples)
+        loss = gflownet.loss(env, training_samples, recalculate_all_logprobs=False)
         loss.backward()
         optimizer.step()
 

--- a/tutorials/examples/train_graph_ring.py
+++ b/tutorials/examples/train_graph_ring.py
@@ -948,7 +948,7 @@ if __name__ == "__main__":
                     training_samples.extend(buffer_samples)  # type: ignore
 
         optimizer.zero_grad()
-        loss = gflownet.loss(env, training_samples)
+        loss = gflownet.loss(env, training_samples, recalculate_all_logprobs=True)
         pct_rings = torch.mean(rewards > 0.1, dtype=torch.float) * 100
         print(
             "Iteration {} - Loss: {:.02f}, rings: {:.0f}%".format(

--- a/tutorials/examples/train_hypergrid.py
+++ b/tutorials/examples/train_hypergrid.py
@@ -240,7 +240,9 @@ def main(args):  # noqa: C901
 
         optimizer.zero_grad()
         gflownet = cast(GFlowNet, gflownet)
-        loss = gflownet.loss(env, training_objects)
+        loss = gflownet.loss(
+            env, training_objects, recalculate_all_logprobs=args.replay_buffer_size > 0
+        )
         loss.backward()
         optimizer.step()
         last_states = trajectories.last_states

--- a/tutorials/examples/train_hypergrid_simple.py
+++ b/tutorials/examples/train_hypergrid_simple.py
@@ -64,7 +64,7 @@ def main(args):
         visited_terminating_states.extend(cast(DiscreteStates, trajectories.last_states))
 
         optimizer.zero_grad()
-        loss = gflownet.loss(env, trajectories)
+        loss = gflownet.loss(env, trajectories, recalculate_all_logprobs=False)
         loss.backward()
         optimizer.step()
         if (it + 1) % args.validation_interval == 0:

--- a/tutorials/examples/train_hypergrid_simple_ls.py
+++ b/tutorials/examples/train_hypergrid_simple_ls.py
@@ -69,7 +69,7 @@ def main(args):
         visited_terminating_states.extend(last_states)
 
         optimizer.zero_grad()
-        loss = gflownet.loss(env, trajectories)
+        loss = gflownet.loss(env, trajectories, recalculate_all_logprobs=False)
         loss.backward()
         optimizer.step()
         if (it + 1) % args.validation_interval == 0:

--- a/tutorials/examples/train_ising.py
+++ b/tutorials/examples/train_ising.py
@@ -89,7 +89,7 @@ def main(args):
         )
         training_samples = gflownet.to_training_samples(trajectories)
         optimizer.zero_grad()
-        loss = gflownet.loss(env, training_samples)
+        loss = gflownet.loss(env, training_samples, recalculate_all_logprobs=True)
         loss.backward()
         optimizer.step()
 

--- a/tutorials/examples/train_line.py
+++ b/tutorials/examples/train_line.py
@@ -249,7 +249,7 @@ def train(
             scale_factor=scale_schedule[iteration],  # Off policy kwargs.
         )
         training_samples = gflownet.to_training_samples(trajectories)
-        loss = gflownet.loss(env, training_samples)
+        loss = gflownet.loss(env, training_samples, recalculate_all_logprobs=True)
         loss.backward()
 
         # Gradient Clipping.


### PR DESCRIPTION
Addresses https://github.com/GFNOrg/torchgfn/issues/248 (with some other modifications):

- `recalculate_all_logprobs` is default `True` everywhere. This is wasteful when training on-policy, but is the safest default behaviour. When the user recalcs logprobs and the container has stored log_probs, a warning is thrown.
- `loss_from_trajectories` now accepts `recalulate_all_logprobs`.
- `FlowMatchingGFlowNet.loss()` now accepts `recalculate_all_logprobs`. This is for API consistency, because as it stands, the container for this loss does not store logprobs. If the user tries to set this, a warning is thrown.