### PR TITLE
Empty container loss fix

### DIFF
--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -47,8 +47,9 @@ class ReplayBuffer:
 
     def add(self, training_objects: ContainerUnion) -> None:
         """Adds a training object to the buffer."""
-        if not isinstance(training_objects, ValidContainerTypes):  # type: ignore
+        if not isinstance(training_objects, ValidContainerTypes):
             raise TypeError("Must be a container type")
+
         self._add_objs(training_objects)
 
     def __repr__(self):
@@ -96,10 +97,12 @@ class ReplayBuffer:
 
             # Ascending sort.
             ix = torch.argsort(self.training_objects.log_rewards)
-            self.training_objects = cast(ContainerUnion, self.training_objects[ix])  # type: ignore
+            self.training_objects = cast(ContainerUnion, self.training_objects[ix])
 
         assert self.training_objects is not None
-        self.training_objects = cast(ContainerUnion, self.training_objects[-self.capacity :])  # type: ignore
+        self.training_objects = cast(
+            ContainerUnion, self.training_objects[-self.capacity :]
+        )
 
     def sample(self, n_trajectories: int) -> ContainerUnion:
         """Samples `n_trajectories` training objects from the buffer."""
@@ -116,6 +119,11 @@ class ReplayBuffer:
         """Loads the buffer from disk."""
         if self.training_objects is not None:
             self.training_objects.load(os.path.join(directory, "training_objects"))
+
+    @property
+    def device(self) -> torch.device:
+        assert self.training_objects is not None, "Buffer is empty, it has no device!"
+        return self.training_objects.device
 
 
 class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
@@ -144,7 +152,7 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
             capacity: the size of the buffer.
             cutoff_distance: threshold used to determine if new terminating_states are
                 different enough from those already contained in the buffer. If the
-                cutoff is negative, all diversity caclulations are skipped (since all
+                cutoff is negative, all diversity calculations are skipped (since all
                 norms are >= 0).
             p_norm_distance: p-norm distance value to pass to torch.cdist, for the
                 determination of novel states.
@@ -155,7 +163,7 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
 
     def add(self, training_objects: ContainerUnion):
         """Adds a training object to the buffer."""
-        if not isinstance(training_objects, ValidContainerTypes):  # type: ignore
+        if not isinstance(training_objects, ValidContainerTypes):
             raise TypeError("Must be a container type")
 
         to_add = len(training_objects)

--- a/src/gfn/containers/states_container.py
+++ b/src/gfn/containers/states_container.py
@@ -206,3 +206,7 @@ class StatesContainer(Container, Generic[StateType]):
             is_terminating=is_terminating,
             log_rewards=log_rewards,
         )
+
+    @property
+    def device(self) -> torch.device:
+        return self.states.device

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -602,6 +602,10 @@ class Trajectories(Container):
 
         return reversed_trajectories
 
+    @property
+    def device(self) -> torch.device:
+        return self.states.device
+
 
 def pad_dim0_to_target(a: torch.Tensor, target_dim0: int) -> torch.Tensor:
     """Pads tensor a to match the dimension of b."""

--- a/src/gfn/containers/transitions.py
+++ b/src/gfn/containers/transitions.py
@@ -299,3 +299,7 @@ class Transitions(Container):
             self.log_probs = torch.cat((self.log_probs, other.log_probs), dim=0)
         else:
             self.log_probs = None
+
+    @property
+    def device(self) -> torch.device:
+        return self.states.device


### PR DESCRIPTION
This should handle all edge cases where an empty container (either pre or post "valid" filtering) is handled properly (returns a loss of 0).