### PR TITLE
states/actions.batch_shape is set automatically

### DIFF
--- a/src/gfn/actions.py
+++ b/src/gfn/actions.py
@@ -314,10 +314,6 @@ class GraphActions(Actions):
         )
 
     def extend(self, other: Actions) -> None:
-        """Extends an Actions instance along the first dimension with dummy actions.
-
-        The Actions instance batch_shape must be 2-dimensional. This is used to pad
-        trajectories actions.
-        """
+        """Extends an Actions instance with another Actions instance."""
         super().extend(other)
         self._batch_shape = self.tensor.batch_size

--- a/src/gfn/actions.py
+++ b/src/gfn/actions.py
@@ -39,7 +39,10 @@ class Actions(ABC):
         ), f"Batched actions tensor has shape {tensor.shape}, but the expected action shape is {self.action_shape}."
 
         self.tensor = tensor
-        self.batch_shape = tuple(self.tensor.shape)[: -len(self.action_shape)]
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return tuple(self.tensor.shape)[: -len(self.action_shape)]
 
     @classmethod
     def make_dummy_actions(cls, batch_shape: tuple[int, ...]) -> Actions:
@@ -96,7 +99,6 @@ class Actions(ABC):
     def extend(self, other: Actions) -> None:
         """Collates to another Actions object of the same batch shape."""
         if len(self.batch_shape) == len(other.batch_shape) == 1:
-            self.batch_shape = (self.batch_shape[0] + other.batch_shape[0],)
             self.tensor = torch.cat((self.tensor, other.tensor), dim=0)
         elif len(self.batch_shape) == len(other.batch_shape) == 2:
             self.extend_with_dummy_actions(
@@ -104,10 +106,6 @@ class Actions(ABC):
             )
             other.extend_with_dummy_actions(
                 required_first_dim=max(self.batch_shape[0], other.batch_shape[0])
-            )
-            self.batch_shape = (
-                self.batch_shape[0],
-                self.batch_shape[1] + other.batch_shape[1],
             )
             self.tensor = torch.cat((self.tensor, other.tensor), dim=1)
         else:
@@ -129,7 +127,6 @@ class Actions(ABC):
                 return
             n = required_first_dim - self.batch_shape[0]
             dummy_actions = self.__class__.make_dummy_actions((n, self.batch_shape[1]))
-            self.batch_shape = (self.batch_shape[0] + n, self.batch_shape[1])
             self.tensor = torch.cat((self.tensor, dummy_actions.tensor), dim=0)
         else:
             raise NotImplementedError(
@@ -210,7 +207,8 @@ class GraphActions(Actions):
             edge_index: an tensor of shape (batch_shape, 2) representing the edge to add.
                 This must defined if and only if the action type is GraphActionType.AddEdge.
         """
-        self.batch_shape = tensor["action_type"].shape
+        self._batch_shape = tensor["action_type"].shape
+
         features = tensor.get("features", None)
         if features is None:
             assert torch.all(
@@ -233,6 +231,10 @@ class GraphActions(Actions):
             },
             batch_size=self.batch_shape,
         )
+
+    @property
+    def batch_shape(self) -> tuple[int, ...]:
+        return self._batch_shape
 
     def __repr__(self):
         return f"""GraphAction object with {self.batch_shape} actions."""
@@ -310,3 +312,12 @@ class GraphActions(Actions):
                 batch_size=batch_shape,
             )
         )
+
+    def extend(self, other: Actions) -> None:
+        """Extends an Actions instance along the first dimension with dummy actions.
+
+        The Actions instance batch_shape must be 2-dimensional. This is used to pad
+        trajectories actions.
+        """
+        super().extend(other)
+        self._batch_shape = self.tensor.batch_size

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -559,7 +559,10 @@ class GraphStates(States):
         """
         self.tensor = tensor
         if not hasattr(self.tensor, "batch_shape"):
-            self.tensor.batch_shape = self.tensor.batch_size  # TODO: Is this correct?
+            if isinstance(self.tensor.batch_size, tuple):
+                self.tensor.batch_shape = self.tensor.batch_size
+            else:
+                self.tensor.batch_shape = (self.tensor.batch_size,)
 
         if tensor.x.size(0) > 0:
             assert tensor.num_graphs == prod(tensor.batch_shape)

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -80,18 +80,13 @@ class States(ABC):
         assert tensor.shape[-len(self.state_shape) :] == self.state_shape
 
         self.tensor = tensor
-        self._batch_shape = tuple(self.tensor.shape)[: -len(self.state_shape)]
         self._log_rewards = (
             None  # Useful attribute if we want to store the log-reward of the states
         )
 
     @property
     def batch_shape(self) -> tuple[int, ...]:
-        return self._batch_shape
-
-    @batch_shape.setter
-    def batch_shape(self, batch_shape: tuple[int, ...]) -> None:
-        self._batch_shape = batch_shape
+        return tuple(self.tensor.shape)[: -len(self.state_shape)]
 
     @classmethod
     def from_batch_shape(
@@ -214,7 +209,6 @@ class States(ABC):
         """
         if len(other.batch_shape) == len(self.batch_shape) == 1:
             # This corresponds to adding a state to a trajectory
-            self.batch_shape = (self.batch_shape[0] + other.batch_shape[0],)
             self.tensor = torch.cat((self.tensor, other.tensor), dim=0)
 
         elif len(other.batch_shape) == len(self.batch_shape) == 2:
@@ -224,10 +218,6 @@ class States(ABC):
             )
             other.extend_with_sf(
                 required_first_dim=max(self.batch_shape[0], other.batch_shape[0])
-            )
-            self.batch_shape = (
-                self.batch_shape[0],
-                self.batch_shape[1] + other.batch_shape[1],
             )
             self.tensor = torch.cat((self.tensor, other.tensor), dim=1)
         else:
@@ -258,7 +248,6 @@ class States(ABC):
                 ),
                 dim=0,
             )
-            self.batch_shape = (required_first_dim, self.batch_shape[1])
         else:
             raise ValueError(
                 f"extend_with_sf is not implemented for graph states nor for batch shapes {self.batch_shape}"
@@ -345,11 +334,6 @@ class States(ABC):
                     raise ValueError("Some states have no log rewards.")
                 log_rewards.append(s._log_rewards)
             stacked_states._log_rewards = torch.stack(log_rewards, dim=0)
-
-        # Adds the trajectory dimension.
-        stacked_states.batch_shape = (
-            stacked_states.tensor.shape[0],
-        ) + state_example.batch_shape
 
         return stacked_states
 
@@ -575,7 +559,7 @@ class GraphStates(States):
         """
         self.tensor = tensor
         if not hasattr(self.tensor, "batch_shape"):
-            self.tensor.batch_shape = self.tensor.batch_size
+            self.tensor.batch_shape = self.tensor.batch_size  # TODO: Is this correct?
 
         if tensor.x.size(0) > 0:
             assert tensor.num_graphs == prod(tensor.batch_shape)


### PR DESCRIPTION
All of the elements where we explicitly set the `self.batch_shape` parameter are removed. This information is now gathered automatically and directly from the `self.tensor` field.


Addresses 
https://github.com/GFNOrg/torchgfn/issues/256