### PR TITLE
Minor refactorings regarding device

### DIFF
--- a/src/gfn/containers/states_container.py
+++ b/src/gfn/containers/states_container.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from gfn.states import States
 
 from gfn.containers.base import Container
+from gfn.utils.common import ensure_same_device
 
 StateType = TypeVar("StateType", bound="States")
 
@@ -47,9 +48,11 @@ class StatesContainer(Container, Generic[StateType]):
 
         # Assert that all tensors are on the same device as the environment.
         device = self.env.device
-        assert states.tensor.device == device if states is not None else True
+        if states is not None:
+            ensure_same_device(states.device, device)
         for tensor in [is_terminating, conditioning, log_rewards]:
-            assert tensor.device == device if tensor is not None else True
+            if tensor is not None:
+                ensure_same_device(tensor.device, device)
 
         self.states = (
             states

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -12,6 +12,7 @@ from gfn.containers.states_container import StatesContainer
 from gfn.containers.transitions import Transitions
 from gfn.env import Env
 from gfn.states import DiscreteStates, GraphStates, States
+from gfn.utils.common import ensure_same_device
 
 
 # TODO: remove env from this class?
@@ -76,17 +77,15 @@ class Trajectories(Container):
 
         # Assert that all tensors are on the same device as the environment.
         device = self.env.device
-        if isinstance(device, str):
-            device = torch.device(device)
 
         for obj in [states, actions]:
             if obj is not None:
                 if isinstance(obj.tensor, GeometricBatch):
-                    assert obj.tensor.x.device == device
+                    ensure_same_device(obj.tensor.x.device, device)
                 elif isinstance(obj.tensor, TensorDict):
-                    assert obj.tensor["x"].device == device
+                    ensure_same_device(obj.tensor["x"].device, device)
                 else:
-                    assert obj.tensor.device == device
+                    ensure_same_device(obj.tensor.device, device)
         for tensor in [
             conditioning,
             terminating_idx,
@@ -94,6 +93,8 @@ class Trajectories(Container):
             log_probs,
             estimator_outputs,
         ]:
+            if tensor is not None:
+                ensure_same_device(tensor.device, device)
             assert tensor.device.type == device.type if tensor is not None else True
 
         self.states = (

--- a/src/gfn/containers/transitions.py
+++ b/src/gfn/containers/transitions.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from gfn.states import States
 
 from gfn.containers.base import Container
+from gfn.utils.common import ensure_same_device
 
 
 class Transitions(Container):
@@ -70,9 +71,11 @@ class Transitions(Container):
         # Assert that all tensors are on the same device as the environment.
         device = self.env.device
         for obj in [states, actions, next_states]:
-            assert obj.tensor.device == device if obj is not None else True
+            if obj is not None:
+                ensure_same_device(obj.tensor.device, device)
         for tensor in [conditioning, is_terminating, log_rewards, log_probs]:
-            assert tensor.device == device if tensor is not None else True
+            if tensor is not None:
+                ensure_same_device(tensor.device, device)
 
         self.states = states if states is not None else env.states_from_batch_shape((0,))
         assert len(self.states.batch_shape) == 1

--- a/src/gfn/env.py
+++ b/src/gfn/env.py
@@ -7,7 +7,7 @@ from torch_geometric.data import Data as GeometricData
 
 from gfn.actions import Actions, GraphActions
 from gfn.states import DiscreteStates, GraphStates, States
-from gfn.utils.common import set_seed
+from gfn.utils.common import ensure_same_device, set_seed
 
 # Errors
 NonValidActionsError = type("NonValidActionsError", (ValueError,), {})
@@ -38,25 +38,29 @@ class Env(ABC):
             sf: Tensor of shape "state_shape" representing the final state.
                 Only used for a human readable representation of the states or trajectories.
         """
+        if isinstance(s0.device, str):  # This can happen when s0 is a GeometricData.
+            s0.device = torch.device(s0.device)
+        assert isinstance(s0.device, torch.device)
+
         self.device = s0.device
         self.s0 = s0
-        assert s0.shape == state_shape
 
         if sf is None:
-            sf = torch.full(s0.shape, -float("inf")).to(self.device)
+            sf = torch.full(s0.shape, -float("inf"))
+        self.sf = sf.to(
+            self.device  # pyright: ignore / torch_geometric has weird type hints.
+        )
 
-        self.sf = sf
-        assert self.sf is not None
-        assert self.sf.device == self.device
-        assert self.sf.shape == state_shape
+        assert self.s0.shape == self.sf.shape == state_shape
+        ensure_same_device(s0.device, sf.device)
 
         self.state_shape = state_shape
         self.action_shape = action_shape
         self.dummy_action = dummy_action.to(self.device)
         self.exit_action = exit_action.to(self.device)
 
-        # Warning: don't use self.States or self.Actions to initialize an instance of the class.
-        # Use self.states_from_tensor or self.actions_from_tensor instead.
+        # Warning: don't use self.States or self.Actions to initialize an instance of
+        # the class. Use self.states_from_tensor or self.actions_from_tensor instead.
         self.States = self.make_states_class()
         self.Actions = self.make_actions_class()
         self.is_discrete = False
@@ -352,7 +356,6 @@ class DiscreteEnv(Env, ABC):
             dummy_action: Optional tensor of shape "action_shape" representing the dummy (padding) action.
             exit_action: Optional tensor of shape "action_shape" representing the exit action.
             sf: Tensor of shape "state_shape" representing the final state tensor (shared among all trajectories).
-            device_str: String representation of a torch.device.
         """
         # Add validation/warnings for advanced usage
         if dummy_action is not None or exit_action is not None or sf is not None:
@@ -580,7 +583,7 @@ class GraphEnv(Env):
             sf: The sink graph state.
             device_str: String representation of the device.
         """
-        assert s0.device == sf.device
+        ensure_same_device(s0.device, sf.device)
         self.device = s0.device
 
         self.s0 = s0

--- a/src/gfn/gym/box.py
+++ b/src/gfn/gym/box.py
@@ -23,14 +23,10 @@ class Box(Env):
         assert 0 < delta <= 1, "delta must be in (0, 1]"
         self.delta = delta
         self.epsilon = epsilon
-        if isinstance(device, str):
-            self.device = torch.device(device)
-        else:
-            self.device = device
 
-        s0 = torch.tensor([0.0, 0.0], device=self.device)
-        exit_action = torch.tensor([-float("inf"), -float("inf")], device=self.device)
-        dummy_action = torch.tensor([float("inf"), float("inf")], device=self.device)
+        s0 = torch.tensor([0.0, 0.0], device=device)
+        exit_action = torch.tensor([-float("inf"), -float("inf")], device=device)
+        dummy_action = torch.tensor([float("inf"), float("inf")], device=device)
 
         self.R0 = R0
         self.R1 = R1

--- a/src/gfn/gym/discrete_ebm.py
+++ b/src/gfn/gym/discrete_ebm.py
@@ -80,8 +80,6 @@ class DiscreteEBM(DiscreteEnv):
             device: Device to use for the environment.
         """
         self.ndim = ndim
-        if isinstance(device, str):
-            device = torch.device(device)
 
         s0 = torch.full((ndim,), -1, dtype=torch.long, device=device)
         sf = torch.full((ndim,), 2, dtype=torch.long, device=device)

--- a/src/gfn/gym/hypergrid.py
+++ b/src/gfn/gym/hypergrid.py
@@ -43,9 +43,6 @@ class HyperGrid(DiscreteEnv):
         self.R2 = R2
         self.reward_cos = reward_cos
 
-        if isinstance(device, str):
-            device = torch.device(device)
-
         s0 = torch.zeros(ndim, dtype=torch.long, device=device)
         sf = torch.full((ndim,), fill_value=-1, dtype=torch.long, device=device)
         n_actions = ndim + 1

--- a/src/gfn/gym/line.py
+++ b/src/gfn/gym/line.py
@@ -27,19 +27,14 @@ class Line(Env):
         self.n_steps_per_trajectory = n_steps_per_trajectory
         self.mixture = [Normal(m, s) for m, s in zip(self.mus, self.sigmas)]
 
-        if isinstance(device, str):
-            device = torch.device(device)
-
-        self.device = device
-
         self.init_value = init_value  # Used in s0.
         lb = torch.min(self.mus) - self.n_sd * torch.max(self.sigmas)
         ub = torch.max(self.mus) + self.n_sd * torch.max(self.sigmas)
         assert lb < self.init_value < ub
 
-        s0 = torch.tensor([self.init_value, 0.0], device=self.device)
-        dummy_action = torch.tensor([float("inf")], device=self.device)
-        exit_action = torch.tensor([-float("inf")], device=self.device)
+        s0 = torch.tensor([self.init_value, 0.0], device=device)
+        dummy_action = torch.tensor([float("inf")], device=device)
+        exit_action = torch.tensor([-float("inf")], device=device)
         super().__init__(
             s0=s0,
             state_shape=(2,),  # [x_pos, step_counter].

--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -8,6 +8,7 @@ from gfn.containers import Trajectories
 from gfn.env import Env
 from gfn.modules import GFNModule
 from gfn.states import States
+from gfn.utils.common import ensure_same_device
 from gfn.utils.handlers import (
     has_conditioning_exception_handler,
     no_conditioning_exception_handler,
@@ -148,7 +149,7 @@ class Sampler:
 
         if conditioning is not None:
             assert states.batch_shape == conditioning.shape[: len(states.batch_shape)]
-            assert conditioning.device == device
+            ensure_same_device(states.device, conditioning.device)
 
         dones = (
             states.is_initial_state

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -157,7 +157,7 @@ class States(ABC):
             f"{self.__class__.__name__}(",
             f"batch={self.batch_shape},",
             f"state={self.state_shape},",
-            f"dev={self.device})",
+            f"device={self.device})",
         ]
         return " ".join(parts)
 
@@ -405,7 +405,7 @@ class DiscreteStates(States, ABC):
             f"batch={self.batch_shape},",
             f"state={self.state_shape},",
             f"actions={self.n_actions},",
-            f"dev={self.device},",
+            f"device={self.device},",
             f"masks={tuple(self.forward_masks.shape)})",
         ]
         return " ".join(parts)
@@ -720,7 +720,7 @@ class GraphStates(States):
             f"state edge_index={self.tensor.edge_index.shape},",
             f"state edge_attr={self.tensor.edge_attr.shape},",
             f"actions={self.n_actions},",
-            f"dev={self.device},",
+            f"device={self.device},",
             f"masks={tuple(self.forward_masks.shape)})",
         ]
         return " ".join(parts)

--- a/src/gfn/utils/common.py
+++ b/src/gfn/utils/common.py
@@ -28,13 +28,20 @@ def ensure_same_device(device1: torch.device, device2: torch.device) -> None:
     if device1.type != device2.type:
         raise ValueError(f"The devices have different types: {device1}, {device2}")
 
-    # Same type but different indices or one is None.
     index1, index2 = device1.index, device2.index
+
+    # Same type and same index.
     if index1 == index2:
         return
 
+    # Both have not-None index but they are different.
+    if index1 is not None and index2 is not None:
+        raise ValueError(f"Device index mismatch: {device1}, {device2}")
+
+    # If one device index is None and the other is not,
+    # the None index defaults to torch.cuda.current_device().
+    # Check that the not-None index matches the current device index.
     current_device = torch.cuda.current_device()
-    # Any non-None index must match the current device.
     for idx in (index1, index2):
         if idx is not None and idx != current_device:
             raise ValueError(f"Device index mismatch: {device1}, {device2}")

--- a/src/gfn/utils/common.py
+++ b/src/gfn/utils/common.py
@@ -18,3 +18,22 @@ def set_seed(seed: int, performance_mode: bool = False) -> None:
     if not performance_mode:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
+
+
+def ensure_same_device(device1: torch.device, device2: torch.device) -> None:
+    """Ensure that two tensors are on the same device."""
+    if device1 == device2:
+        return
+
+    # Devices are different due to the different indices.
+    if device1.type == device2.type:
+        index1, index2 = device1.index, device2.index
+
+        # Case 1: They have different indices, which is problematic.
+        if index1 is not None and index2 is not None:
+            raise ValueError(f"The devices have different indices: {device1}, {device2}")
+        # Case 2: At least one of them has None index, which is fine for now.
+        else:
+            return  # FIXME: This could be problematic if we use multiple GPUs.
+
+    raise ValueError(f"The devices are different: {device1}, {device2}")

--- a/tutorials/examples/train_ising.py
+++ b/tutorials/examples/train_ising.py
@@ -19,7 +19,9 @@ def main(args):
         wandb.init(project=args.wandb_project)
         wandb.config.update(args)
 
-    device = torch.device(args.device)
+    device = torch.device(
+        "cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu"
+    )
     torch.set_num_threads(args.n_threads)
     hidden_dim = 512
 
@@ -101,12 +103,7 @@ def main(args):
 if __name__ == "__main__":
     parser = ArgumentParser()
 
-    parser.add_argument(
-        "--device",
-        type=str,
-        default="cpu",
-        help="Device to run the model on",
-    )
+    parser.add_argument("--no_cuda", action="store_true", help="Prevent CUDA usage")
 
     parser.add_argument(
         "--n_threads",

--- a/tutorials/examples/train_line.py
+++ b/tutorials/examples/train_line.py
@@ -280,7 +280,9 @@ def train(
 
 
 def main(args: Namespace):
-    device = torch.device(args.device) if isinstance(args.device, str) else args.device
+    if not isinstance(args.device, torch.device):
+        device = torch.device(args.device)
+
     environment = Line(
         mus=[2, 5],
         sigmas=[0.5, 0.5],


### PR DESCRIPTION
### Summary of this PR

1. Add helper function `ensure_same_device` in `utils.common` for device comparison. Previously, we had assertion `assert a.device == b.device`. But this is annoying when `a.device` is `torch.device("cuda")` and `b.device` is `torch.device("cuda:0")`. This PR resolves this issue.
2. When initializing an env, assigning a device to `s0` is enough; then the super env class will do `self.device = s0.device`. I removed some redundancy in this regard.