### PR TITLE
Fix extend of GraphStates with 2d batch_shape

### DIFF
--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -891,7 +891,7 @@ class GraphStates(States):
         else:
             # Handle the case where batch_shape is (T, B)
             # and we want to concatenate along the B dimension
-            assert len(self.batch_shape) == 2
+            assert len(self.batch_shape) == 2 and len(other.batch_shape) == 2
             max_len = max(self.batch_shape[0], other.batch_shape[0])
 
             # We need to extend both batches to the same length T
@@ -909,7 +909,17 @@ class GraphStates(States):
 
             # Now both have the same length T, we can concatenate along B
             batch_shape = (max_len, self.batch_shape[1] + other.batch_shape[1])
-            self.tensor = GeometricBatch.from_data_list(self_data_list + other_data_list)
+            new_data_list = []
+            for i in range(max_len):
+                new_data_list.extend(
+                    self_data_list[
+                        i * self.batch_shape[1] : (i + 1) * self.batch_shape[1]
+                    ]
+                    + other_data_list[
+                        i * other.batch_shape[1] : (i + 1) * other.batch_shape[1]
+                    ]
+                )
+            self.tensor = GeometricBatch.from_data_list(new_data_list)
             self.tensor.batch_shape = batch_shape
 
         # Combine log rewards if they exist


### PR DESCRIPTION
This fixes [this error](https://github.com/GFNOrg/torchgfn/pull/296#issuecomment-2761479074).

We shouldn't have simply concatenated two`data_list`s.

Here is an example:
Let's say, `max_len == 3`, `states1.batch_shape == (3, 2)`, and `states2.batch_shape == (3, 1)`.

Note that `GeometricData.to_data_list` should be aligned with the flattened index, which means that:
- `states1[0, 0] == states1.to_data_list[0]`
- `states1[0, 1] == states1.to_data_list[1]`
...
- `states1[2, 1] == states1.to_data_list[5]`

Similarly, for the concatenated states (`new_states`),
- `new_states[0, 0] == states1[0, 0] == new_states.to_data_list[0]`
- `new_states[0, 1] == states1[0, 1] == new_states.to_data_list[1]`
- `new_states[0, 2] == states2[0, 0] == new_states.to_data_list[2]`  <-- This was wrong.
...
- `new_states[2, 1] == states1[2, 1] == new_states.to_data_list[7]`  <-- This was wrong.
- `new_states[2, 2] == states2[2, 0] == new_states.to_data_list[8]`