### PR TITLE
Solves issue #303

### DIFF
--- a/src/gfn/gflownet/detailed_balance.py
+++ b/src/gfn/gflownet/detailed_balance.py
@@ -211,7 +211,7 @@ class DBGFlowNet(PFBasedGFlowNet[Transitions]):
         scores = scores**2
         loss = loss_reduce(scores, reduction)
 
-        if torch.isnan(loss):
+        if torch.isnan(loss).any():
             raise ValueError("loss is nan")
 
         return loss

--- a/src/gfn/gflownet/trajectory_balance.py
+++ b/src/gfn/gflownet/trajectory_balance.py
@@ -84,7 +84,7 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
         logZ = cast(torch.Tensor, logZ)
         scores = (scores + logZ.squeeze()).pow(2)
         loss = loss_reduce(scores, reduction)
-        if torch.isnan(loss):
+        if torch.isnan(loss).any():
             raise ValueError("loss is nan")
 
         return loss
@@ -128,7 +128,7 @@ class LogPartitionVarianceGFlowNet(TrajectoryBasedGFlowNet):
         )
         scores = (scores - scores.mean()).pow(2)
         loss = loss_reduce(scores, reduction)
-        if torch.isnan(loss):
+        if torch.isnan(loss).any():
             raise ValueError("loss is NaN.")
 
         return loss


### PR DESCRIPTION
Solves #303 
Recently, the option to not reduce, reduce by mean and reduce by sum the loss of TBGflowNet and DBGflowNet was added. 
In the case where no reduction was done, the `if torch.isnan(loss)` was throwing the error 

> RuntimeError: Boolean value of Tensor with more than one value is ambiguous

This PR solves this by adding `.any()` in the condition.