### PR TITLE
Added custom log_reward option to GFlowNets.

### DIFF
--- a/src/gfn/gflownet/base.py
+++ b/src/gfn/gflownet/base.py
@@ -1,6 +1,6 @@
 import math
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Tuple, TypeVar
+from typing import Any, Generic, Optional, Tuple, TypeVar
 
 import torch
 import torch.nn as nn
@@ -204,12 +204,15 @@ class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):
     def get_trajectories_scores(
         self,
         trajectories: Trajectories,
+        log_rewards: Optional[torch.Tensor] = None,
         recalculate_all_logprobs: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Given a batch of trajectories, calculate forward & backward policy scores.
 
         Args:
             trajectories: Trajectories to evaluate.
+            log_rewards: Log rewards to use. If None, use the log_rewards from the
+                trajectories.
             recalculate_all_logprobs: Whether to re-evaluate all logprobs.
 
         Returns: A tuple of float tensors of shape (n_trajectories,)
@@ -224,7 +227,10 @@ class TrajectoryBasedGFlowNet(PFBasedGFlowNet[Trajectories]):
         total_log_pf_trajectories = log_pf_trajectories.sum(dim=0)
         total_log_pb_trajectories = log_pb_trajectories.sum(dim=0)
 
-        log_rewards = trajectories.log_rewards
+        if log_rewards is None:
+            log_rewards = trajectories.log_rewards
+        assert log_rewards is not None
+        assert log_rewards.shape == (trajectories.n_trajectories,)
 
         if math.isfinite(self.log_reward_clip_min) and log_rewards is not None:
             log_rewards = log_rewards.clamp_min(self.log_reward_clip_min)

--- a/src/gfn/gflownet/trajectory_balance.py
+++ b/src/gfn/gflownet/trajectory_balance.py
@@ -3,7 +3,7 @@ Implementations of the [Trajectory Balance loss](https://arxiv.org/abs/2201.1325
 and the [Log Partition Variance loss](https://arxiv.org/abs/2302.05446).
 """
 
-from typing import cast
+from typing import Optional, cast
 
 import torch
 import torch.nn as nn
@@ -55,6 +55,7 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
         self,
         env: Env,
         trajectories: Trajectories,
+        log_rewards: Optional[torch.Tensor] = None,
         recalculate_all_logprobs: bool = True,
         reduction: str = "mean",
     ) -> torch.Tensor:
@@ -69,7 +70,7 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
         del env  # unused
         warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
         _, _, scores = self.get_trajectories_scores(
-            trajectories, recalculate_all_logprobs=recalculate_all_logprobs
+            trajectories, log_rewards, recalculate_all_logprobs=recalculate_all_logprobs
         )
 
         # If the conditioning values exist, we pass them to self.logZ
@@ -113,6 +114,7 @@ class LogPartitionVarianceGFlowNet(TrajectoryBasedGFlowNet):
         self,
         env: Env,
         trajectories: Trajectories,
+        log_rewards: Optional[torch.Tensor] = None,
         recalculate_all_logprobs: bool = True,
         reduction: str = "mean",
     ) -> torch.Tensor:
@@ -124,7 +126,7 @@ class LogPartitionVarianceGFlowNet(TrajectoryBasedGFlowNet):
         del env  # unused
         warn_about_recalculating_logprobs(trajectories, recalculate_all_logprobs)
         _, _, scores = self.get_trajectories_scores(
-            trajectories, recalculate_all_logprobs=recalculate_all_logprobs
+            trajectories, log_rewards, recalculate_all_logprobs=recalculate_all_logprobs
         )
         scores = (scores - scores.mean()).pow(2)
         loss = loss_reduce(scores, reduction)


### PR DESCRIPTION

This pull request adds support for using custom rewards in GFlowNet implementations, enabling the use of intrinsic rewards for example (https://openreview.net/forum?id=HH4KWP8RP5).

## Changes

- Added a `log_rewards` argument to GFlowNet implementations.
  - By default, it is set to `None`, in which case the environment's reward is used. This preserves compatibility with existing code.
  - When provided, `log_rewards` is expected to be a tensor of the same shape as the container (e.g., `(n_trajectories,)`, `(n_transitions,)`, etc.), and it's used instead of the environment reward.

- In the DB and SubTB losses, I did not modify the forward-looking setup, except to rename the argument to `fl_log_rewards` to avoid naming conflicts.
  - I am not sure what this forward-looking setup does exactly (would appreciate any pointers to the original reference).
  - For now, I recommend using custom rewards with caution when using the forward-looking setup.
