### PR TITLE
Fix device checking in `Env` class

### DIFF
--- a/src/gfn/env.py
+++ b/src/gfn/env.py
@@ -51,7 +51,7 @@ class Env(ABC):
         )
 
         assert self.s0.shape == self.sf.shape == state_shape
-        ensure_same_device(s0.device, sf.device)
+        ensure_same_device(self.s0.device, self.sf.device)
 
         self.state_shape = state_shape
         self.action_shape = action_shape

--- a/src/gfn/env.py
+++ b/src/gfn/env.py
@@ -51,7 +51,6 @@ class Env(ABC):
         )
 
         assert self.s0.shape == self.sf.shape == state_shape
-        ensure_same_device(self.s0.device, self.sf.device)
 
         self.state_shape = state_shape
         self.action_shape = action_shape


### PR DESCRIPTION
`ensure_same_device` used `sf` and `s0` as inputs, but only `self.sf` is sent to `s0`'s device