### PR TITLE
Fix graph modules

### DIFF
--- a/src/gfn/utils/modules.py
+++ b/src/gfn/utils/modules.py
@@ -5,7 +5,6 @@ from typing import Literal, Optional
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from linear_attention_transformer import LinearAttentionTransformer
 from tensordict import TensorDict
 from torch_geometric.data import Batch as GeometricBatch
@@ -458,12 +457,12 @@ class GraphEdgeActionGNN(nn.Module):
             "-inf"
         )
         if self.is_backward:
-            action_type[..., GraphActionType.ADD_EDGE] = 1
+            action_type[..., GraphActionType.ADD_EDGE] = 0.0
         else:
             node_feature_means = self._group_mean(x, batch_ptr)
             exit_action = self.exit_mlp(node_feature_means).squeeze(-1)
-            action_type[..., GraphActionType.ADD_EDGE] = F.logsigmoid(-exit_action)
-            action_type[..., GraphActionType.EXIT] = F.logsigmoid(exit_action)
+            action_type[..., GraphActionType.ADD_EDGE] = 0.0
+            action_type[..., GraphActionType.EXIT] = exit_action
 
         return TensorDict(
             {
@@ -627,11 +626,11 @@ class GraphEdgeActionMLP(nn.Module):
             "-inf"
         )
         if self.is_backward:
-            action_type[..., GraphActionType.ADD_EDGE] = 1
+            action_type[..., GraphActionType.ADD_EDGE] = 0.0
         else:
             exit_action = self.exit_mlp(embedding).squeeze(-1)
-            action_type[..., GraphActionType.ADD_EDGE] = F.logsigmoid(-exit_action)
-            action_type[..., GraphActionType.EXIT] = F.logsigmoid(exit_action)
+            action_type[..., GraphActionType.ADD_EDGE] = 0.0
+            action_type[..., GraphActionType.EXIT] = exit_action
 
         return TensorDict(
             {

--- a/src/gfn/utils/modules.py
+++ b/src/gfn/utils/modules.py
@@ -450,13 +450,13 @@ class GraphEdgeActionGNN(nn.Module):
         # Grab the needed elements from the adjacency matrix and reshape.
         edge_actions = edgewise_dot_prod[torch.arange(batch_size)[:, None, None], i0, i1]
         edge_actions = edge_actions.reshape(
-            *states_tensor["batch_shape"],
+            *states_tensor.batch_shape,
             self.edges_dim,
         )
 
-        action_type = torch.ones(
-            *states_tensor["batch_shape"], 3, device=x.device
-        ) * float("-inf")
+        action_type = torch.ones(*states_tensor.batch_shape, 3, device=x.device) * float(
+            "-inf"
+        )
         if self.is_backward:
             action_type[..., GraphActionType.ADD_EDGE] = 1
         else:
@@ -469,14 +469,14 @@ class GraphEdgeActionGNN(nn.Module):
             {
                 GraphActions.ACTION_TYPE_KEY: action_type,
                 GraphActions.EDGE_CLASS_KEY: torch.zeros(
-                    *states_tensor["batch_shape"], self.num_edge_classes, device=x.device
+                    *states_tensor.batch_shape, self.num_edge_classes, device=x.device
                 ),  # TODO: make it learnable.
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
-                    *states_tensor["batch_shape"], 1, device=x.device
+                    *states_tensor.batch_shape, 1, device=x.device
                 ),
                 GraphActions.EDGE_INDEX_KEY: edge_actions,
             },
-            batch_size=states_tensor["batch_shape"],
+            batch_size=states_tensor.batch_shape,
         )
 
 
@@ -623,9 +623,9 @@ class GraphEdgeActionMLP(nn.Module):
         # Generate edge and exit actions
         edge_actions = self.edge_mlp(embedding)
 
-        action_type = torch.ones(
-            *states_tensor["batch_shape"], 3, device=device
-        ) * float("-inf")
+        action_type = torch.ones(*states_tensor.batch_shape, 3, device=device) * float(
+            "-inf"
+        )
         if self.is_backward:
             action_type[..., GraphActionType.ADD_EDGE] = 1
         else:
@@ -637,14 +637,14 @@ class GraphEdgeActionMLP(nn.Module):
             {
                 GraphActions.ACTION_TYPE_KEY: action_type,
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
-                    *states_tensor["batch_shape"], 1, device=device
+                    *states_tensor.batch_shape, 1, device=device
                 ),
                 GraphActions.EDGE_CLASS_KEY: torch.zeros(
-                    *states_tensor["batch_shape"], self.num_edge_classes, device=device
+                    *states_tensor.batch_shape, self.num_edge_classes, device=device
                 ),  # TODO: make it learnable
                 GraphActions.EDGE_INDEX_KEY: edge_actions,
             },
-            batch_size=states_tensor["batch_shape"],
+            batch_size=states_tensor.batch_shape,
         )
 
 


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [x] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description
I found a counter-intuitive design in the calculation of logits for `exit_action` in the modules for graph states. Specifically, in `GraphEdgeActionGNN`,
```python
            action_type[..., GraphActionType.ADD_EDGE] = 1 - exit_action
            action_type[..., GraphActionType.EXIT] = exit_action
```
This doesn't make sense since exit_action is not a probability but a logit. I fixed this as follows:
```python
            action_type[..., GraphActionType.ADD_EDGE] = F.logsigmoid(-exit_action)
            action_type[..., GraphActionType.EXIT] = F.logsigmoid(exit_action)
```
Note that `F.logsigmoid(-exit_action) == (1 - F.sigmoid(exit_action)).log()`.

Please review the changes for details.