### PR TITLE
remove deepcopy completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,5 @@ scripts.py
 models/
 *.DS_Store
 .python-version
+
+.lprof

--- a/src/gfn/gym/bitSequence.py
+++ b/src/gfn/gym/bitSequence.py
@@ -351,7 +351,7 @@ class BitSequence(DiscreteEnv):
                 states.length - 1,
             ]
         ).all()
-        old_tensor = states.tensor.clone()
+        old_tensor = states.tensor
         old_tensor[..., states.length - 1] = -1
         return self.States(old_tensor)
 

--- a/src/gfn/modules.py
+++ b/src/gfn/modules.py
@@ -211,8 +211,7 @@ class ScalarEstimator(GFNModule):
         if out.shape[-1] != 1:
             out = self.reduction_fxn(out, -1)
 
-        if __debug__:
-            assert out.shape[-1] == 1
+        assert out.shape[-1] == 1
 
         return out
 
@@ -368,9 +367,7 @@ class ConditionalDiscretePolicyEstimator(DiscretePolicyEstimator):
         Returns the output of the module, as a tensor of shape (*batch_shape, output_dim).
         """
         out = self._forward_trunk(states, conditioning)
-        if __debug__:
-            assert out.shape[-1] == self.expected_output_dim
-
+        assert out.shape[-1] == self.expected_output_dim
         return out
 
 

--- a/src/gfn/modules.py
+++ b/src/gfn/modules.py
@@ -211,7 +211,9 @@ class ScalarEstimator(GFNModule):
         if out.shape[-1] != 1:
             out = self.reduction_fxn(out, -1)
 
-        assert out.shape[-1] == 1
+        if __debug__:
+            assert out.shape[-1] == 1
+
         return out
 
 
@@ -366,7 +368,9 @@ class ConditionalDiscretePolicyEstimator(DiscretePolicyEstimator):
         Returns the output of the module, as a tensor of shape (*batch_shape, output_dim).
         """
         out = self._forward_trunk(states, conditioning)
-        assert out.shape[-1] == self.expected_output_dim
+        if __debug__:
+            assert out.shape[-1] == self.expected_output_dim
+
         return out
 
 

--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -240,7 +240,9 @@ class Sampler:
                 assert new_states is not states
                 assert isinstance(new_states, States)
                 assert type(new_states) is type(states)
-                if isinstance(new_states, GraphStates):
+                if isinstance(new_states, GraphStates) and isinstance(
+                    states, GraphStates
+                ):
                     # Asserts that there exists no shared storage between the two
                     # GraphStates.
                     assert not graph_states_share_storage(new_states, states)

--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Any, List, Optional, Tuple
 
 import torch
@@ -163,14 +162,14 @@ class Sampler:
         )
 
         # Define dummy actions to avoid errors when stacking empty lists.
-        dummy_actions = env.actions_from_batch_shape((n_trajectories,))
-        dummy_logprobs = torch.full(
-            (n_trajectories,), fill_value=0, dtype=torch.float, device=device
-        )
 
-        trajectories_states: List[States] = [deepcopy(states)]
-        trajectories_actions: List[Actions] = [dummy_actions]
-        trajectories_logprobs: List[torch.Tensor] = [dummy_logprobs]
+        trajectories_states: List[States] = [states]
+        trajectories_actions: List[Actions] = [
+            env.actions_from_batch_shape((n_trajectories,))
+        ]
+        trajectories_logprobs: List[torch.Tensor] = [
+            torch.full((n_trajectories,), fill_value=0, dtype=torch.float, device=device)
+        ]
         trajectories_terminating_idx = torch.zeros(
             n_trajectories, dtype=torch.long, device=device
         )
@@ -182,8 +181,10 @@ class Sampler:
         all_estimator_outputs = []
 
         while not all(dones):
-            actions = deepcopy(dummy_actions)
-            log_probs = dummy_logprobs.clone()
+            actions = env.actions_from_batch_shape((n_trajectories,))
+            log_probs = torch.full(
+                (n_trajectories,), fill_value=0, dtype=torch.float, device=device
+            )
             # This optionally allows you to retrieve the estimator_outputs collected
             # during sampling. This is useful if, for example, you want to evaluate off
             # policy actions later without repeating calculations to obtain the env
@@ -248,7 +249,7 @@ class Sampler:
 
             states = new_states
             dones = dones | new_dones
-            trajectories_states.append(deepcopy(states))
+            trajectories_states.append(states)
 
         # Stack all states and actions
         stacked_states = env.States.stack(trajectories_states)

--- a/src/gfn/samplers.py
+++ b/src/gfn/samplers.py
@@ -93,10 +93,9 @@ class Sampler:
         if not save_estimator_outputs:
             estimator_output = None
 
-        if __debug__:
-            assert log_probs is None or log_probs.shape == actions.batch_shape
-            # assert estimator_output is None or estimator_output.shape == actions.batch_shape
-            # TODO: check expected shape
+        assert log_probs is None or log_probs.shape == actions.batch_shape
+        # assert estimator_output is None or estimator_output.shape == actions.batch_shape
+        # TODO: check expected shape
 
         return actions, log_probs, estimator_output
 
@@ -142,10 +141,9 @@ class Sampler:
             states = env.reset(batch_shape=(n,))
             n_trajectories = n
         else:
-            if __debug__:
-                assert (
-                    len(states.batch_shape) == 1
-                ), "States should have len(states.batch_shape) == 1, w/ no trajectory dim!"
+            assert (
+                len(states.batch_shape) == 1
+            ), "States should have len(states.batch_shape) == 1, w/ no trajectory dim!"
             n_trajectories = states.batch_shape[0]
             # Backward trajectories should have the reward at the beginning (terminating state)
             if self.estimator.is_backward:
@@ -156,11 +154,8 @@ class Sampler:
         device = states.device
 
         if conditioning is not None:
-            if __debug__:
-                assert (
-                    states.batch_shape == conditioning.shape[: len(states.batch_shape)]
-                )
-                ensure_same_device(states.device, conditioning.device)
+            assert states.batch_shape == conditioning.shape[: len(states.batch_shape)]
+            ensure_same_device(states.device, conditioning.device)
 
         dones = (
             states.is_initial_state
@@ -236,20 +231,17 @@ class Sampler:
                 new_states = env._step(states, actions)
 
             # Ensure that the new state is a distinct object from the old state.
-            if __debug__:
-                assert new_states is not states
-                assert isinstance(new_states, States)
-                assert type(new_states) is type(states)
-                if isinstance(new_states, GraphStates) and isinstance(
-                    states, GraphStates
-                ):
-                    # Asserts that there exists no shared storage between the two
-                    # GraphStates.
-                    assert not graph_states_share_storage(new_states, states)
-                else:
-                    # Asserts that there exists no shared storage between the two
-                    # States.
-                    assert new_states.tensor.data_ptr() != states.tensor.data_ptr()
+            assert new_states is not states
+            assert isinstance(new_states, States)
+            assert type(new_states) is type(states)
+            if isinstance(new_states, GraphStates) and isinstance(states, GraphStates):
+                # Asserts that there exists no shared storage between the two
+                # GraphStates.
+                assert not graph_states_share_storage(new_states, states)
+            else:
+                # Asserts that there exists no shared storage between the two
+                # States.
+                assert new_states.tensor.data_ptr() != states.tensor.data_ptr()
 
             # Increment the step, determine which trajectories are finished, and eval
             # rewards.
@@ -770,25 +762,20 @@ class LocalSearchSampler(Sampler):
                         recon_trajectories_log_pb[:_len_recon, i]
                     )
 
-            if __debug__:
-                assert torch.all(
-                    _new_trajectories_states_tsr == new_trajectories_states_tsr
-                )
-                assert torch.all(
-                    _new_trajectories_actions_tsr == new_trajectories_actions_tsr
-                )
+            assert torch.all(_new_trajectories_states_tsr == new_trajectories_states_tsr)
+            assert torch.all(
+                _new_trajectories_actions_tsr == new_trajectories_actions_tsr
+            )
             if (
                 prev_trajectories_log_pf is not None
                 and recon_trajectories_log_pf is not None
             ):
-                if __debug__:
-                    assert torch.all(_new_trajectories_log_pf == new_trajectories_log_pf)
+                assert torch.all(_new_trajectories_log_pf == new_trajectories_log_pf)
             if (
                 prev_trajectories_log_pb is not None
                 and recon_trajectories_log_pb is not None
             ):
-                if __debug__:
-                    assert torch.all(_new_trajectories_log_pb == new_trajectories_log_pb)
+                assert torch.all(_new_trajectories_log_pb == new_trajectories_log_pb)
 
         new_trajectories = Trajectories(
             env=env,

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -75,9 +75,10 @@ class States(ABC):
         Args:
             tensor: Tensor of shape (*batch_shape, *state_shape) representing a batch of states.
         """
-        assert self.s0.shape == self.state_shape
-        assert self.sf.shape == self.state_shape
-        assert tensor.shape[-len(self.state_shape) :] == self.state_shape
+        if __debug__:
+            assert self.s0.shape == self.state_shape
+            assert self.sf.shape == self.state_shape
+            assert tensor.shape[-len(self.state_shape) :] == self.state_shape
 
         self.tensor = tensor
         self._log_rewards = (
@@ -327,9 +328,10 @@ class States(ABC):
     def stack(cls, states: Sequence[States]) -> States:
         """Given a list of states, stacks them along a new dimension (0)."""
         state_example = states[0]
-        assert all(
-            state.batch_shape == state_example.batch_shape for state in states
-        ), "All states must have the same batch_shape"
+        if __debug__:
+            assert all(
+                state.batch_shape == state_example.batch_shape for state in states
+            ), "All states must have the same batch_shape"
 
         stacked_states = state_example.from_batch_shape(
             (0, 0), device=state_example.device
@@ -377,7 +379,9 @@ class DiscreteStates(States, ABC):
                 allowable backward policy actions.
         """
         super().__init__(tensor)
-        assert tensor.shape == self.batch_shape + self.state_shape
+
+        if __debug__:
+            assert tensor.shape == self.batch_shape + self.state_shape
 
         # In the usual case, no masks are provided and we produce these defaults.
         # Note: this **must** be updated externally by the env.
@@ -396,8 +400,10 @@ class DiscreteStates(States, ABC):
 
         self.forward_masks: torch.Tensor = forward_masks
         self.backward_masks: torch.Tensor = backward_masks
-        assert self.forward_masks.shape == (*self.batch_shape, self.n_actions)
-        assert self.backward_masks.shape == (*self.batch_shape, self.n_actions - 1)
+
+        if __debug__:
+            assert self.forward_masks.shape == (*self.batch_shape, self.n_actions)
+            assert self.backward_masks.shape == (*self.batch_shape, self.n_actions - 1)
 
     def clone(self) -> DiscreteStates:
         """Returns a clone of the current instance."""
@@ -585,7 +591,8 @@ class GraphStates(States):
             if self._device is None:
                 self._device = cast(torch.Tensor, g.x).device
             else:
-                ensure_same_device(self._device, cast(torch.Tensor, g.x).device)
+                if __debug__:
+                    ensure_same_device(self._device, cast(torch.Tensor, g.x).device)
 
     @property
     def tensor(self) -> GeometricBatch:
@@ -1052,7 +1059,8 @@ class GraphStates(States):
         """
         # Check that all states have the same batch shape
         state_batch_shape = states[0].batch_shape
-        assert all(state.batch_shape == state_batch_shape for state in states)
+        if __debug__:
+            assert all(state.batch_shape == state_batch_shape for state in states)
 
         graphs_list = [state.data for state in states]
         stacked_graphs = np.stack(graphs_list)

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -1084,7 +1084,7 @@ class GraphStates(States):
 def graph_states_share_storage(a: GraphStates, b: GraphStates) -> bool:
     """True if *any* tensor storage is shared between the two GraphStates."""
 
-    def _tensor_ptrs(g: Data) -> tuple[int, ...]:
+    def _tensor_ptrs(g: GeometricData) -> tuple[int, ...]:
         """Return the data_ptr() of every tensor field in the graph."""
         out: list[int] = []
         for key, t in g:

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -75,10 +75,9 @@ class States(ABC):
         Args:
             tensor: Tensor of shape (*batch_shape, *state_shape) representing a batch of states.
         """
-        if __debug__:
-            assert self.s0.shape == self.state_shape
-            assert self.sf.shape == self.state_shape
-            assert tensor.shape[-len(self.state_shape) :] == self.state_shape
+        assert self.s0.shape == self.state_shape
+        assert self.sf.shape == self.state_shape
+        assert tensor.shape[-len(self.state_shape) :] == self.state_shape
 
         self.tensor = tensor
         self._log_rewards = (
@@ -328,10 +327,9 @@ class States(ABC):
     def stack(cls, states: Sequence[States]) -> States:
         """Given a list of states, stacks them along a new dimension (0)."""
         state_example = states[0]
-        if __debug__:
-            assert all(
-                state.batch_shape == state_example.batch_shape for state in states
-            ), "All states must have the same batch_shape"
+        assert all(
+            state.batch_shape == state_example.batch_shape for state in states
+        ), "All states must have the same batch_shape"
 
         stacked_states = state_example.from_batch_shape(
             (0, 0), device=state_example.device
@@ -379,9 +377,7 @@ class DiscreteStates(States, ABC):
                 allowable backward policy actions.
         """
         super().__init__(tensor)
-
-        if __debug__:
-            assert tensor.shape == self.batch_shape + self.state_shape
+        assert tensor.shape == self.batch_shape + self.state_shape
 
         # In the usual case, no masks are provided and we produce these defaults.
         # Note: this **must** be updated externally by the env.
@@ -401,9 +397,8 @@ class DiscreteStates(States, ABC):
         self.forward_masks: torch.Tensor = forward_masks
         self.backward_masks: torch.Tensor = backward_masks
 
-        if __debug__:
-            assert self.forward_masks.shape == (*self.batch_shape, self.n_actions)
-            assert self.backward_masks.shape == (*self.batch_shape, self.n_actions - 1)
+        assert self.forward_masks.shape == (*self.batch_shape, self.n_actions)
+        assert self.backward_masks.shape == (*self.batch_shape, self.n_actions - 1)
 
     def clone(self) -> DiscreteStates:
         """Returns a clone of the current instance."""
@@ -591,8 +586,7 @@ class GraphStates(States):
             if self._device is None:
                 self._device = cast(torch.Tensor, g.x).device
             else:
-                if __debug__:
-                    ensure_same_device(self._device, cast(torch.Tensor, g.x).device)
+                ensure_same_device(self._device, cast(torch.Tensor, g.x).device)
 
     @property
     def tensor(self) -> GeometricBatch:
@@ -1059,8 +1053,7 @@ class GraphStates(States):
         """
         # Check that all states have the same batch shape
         state_batch_shape = states[0].batch_shape
-        if __debug__:
-            assert all(state.batch_shape == state_batch_shape for state in states)
+        assert all(state.batch_shape == state_batch_shape for state in states)
 
         graphs_list = [state.data for state in states]
         stacked_graphs = np.stack(graphs_list)

--- a/src/gfn/utils/graphs.py
+++ b/src/gfn/utils/graphs.py
@@ -297,3 +297,23 @@ class GeometricBatch(Batch):
         )
         batch.batch_shape = (len(data_list),) + single_batch_shape
         return batch
+
+
+def data_share_storage(a: Data, b: Data) -> bool:
+    """True ⇢ every tensor attribute in `a` points to the same storage in `b`.
+
+    Args:
+        a: The first Data object.
+        b: The second Data object.
+
+    Returns:
+        True if every tensor attribute in `a` points to the same storage in `b`,
+        False otherwise.
+    """
+    for key, ta in a:
+        if not torch.is_tensor(ta):
+            continue
+        tb = getattr(b, key, None)
+        if not (torch.is_tensor(tb) and ta.data_ptr() == tb.data_ptr()):
+            return False
+    return True


### PR DESCRIPTION
<!-- 
IMPORTANT: Please review our contribution guidelines before submitting this PR:
https://github.com/GFNOrg/torchgfn/blob/main/.github/CONTRIBUTING.md

This repo has strict requirements for:
- Type annotations (checked with pyright)
- Test coverage
- VSCode configuration (pyright extension recommended)

PR checklist:
-->

- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [x] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

- Removes `deepcopy` from `sampler.py` and makes appropriate changes to `state.py` to support this (via modifications to `state.clone()`). This also uncovered a bug in the bitsequence environment (which was masked by the `deepcopy` operation) which was also fixed. 

This should drastically reduce overhead during training.
