### PR TITLE
Timing profile added for multinode

### DIFF
--- a/tutorials/examples/train_box.py
+++ b/tutorials/examples/train_box.py
@@ -12,12 +12,12 @@ from typing import Optional, Union
 
 import numpy as np
 import torch
+import wandb
 from numpy.typing import NDArray
 from scipy.special import logsumexp
 from sklearn.neighbors import KernelDensity
 from tqdm import tqdm, trange
 
-import wandb
 from gfn.gflownet import (
     DBGFlowNet,
     LogPartitionVarianceGFlowNet,

--- a/tutorials/examples/train_discreteebm.py
+++ b/tutorials/examples/train_discreteebm.py
@@ -15,9 +15,9 @@ from argparse import ArgumentParser
 from typing import cast
 
 import torch
+import wandb
 from tqdm import tqdm, trange
 
-import wandb
 from gfn.gflownet import FMGFlowNet
 from gfn.gym import DiscreteEBM
 from gfn.modules import DiscretePolicyEstimator

--- a/tutorials/examples/train_ising.py
+++ b/tutorials/examples/train_ising.py
@@ -1,9 +1,9 @@
 from argparse import ArgumentParser
 
 import torch
+import wandb
 from tqdm import tqdm
 
-import wandb
 from gfn.gflownet import FMGFlowNet
 from gfn.gym import DiscreteEBM
 from gfn.gym.discrete_ebm import IsingModel


### PR DESCRIPTION
<!-- 
PR checklist:
-->

- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

This PR includes code to track and report the runtime of important steps, which can be useful for identifying bottlenecks and analyzing performance in both single-node and multi-node settings.

### Key Changes

**1. Context-based Timer Utility**

  Introduced a `Timer` class that measures the runtime of code blocks using a context manager. This approach minimizes errors by avoiding the need for manual start/end time tracking.

  **Usage:** 

```python
with Timer(timing, "step1"):
        # Code block to time
        do_something()
```
  This stores the runtime of `do_something()` in the `timing` dictionary with the key `"step1"`.

**2. Timing Report Output**

  At the end of execution, timing information is reported in a structured format:

  * For single node run: 
  ![image](https://github.com/user-attachments/assets/3396e748-fc3b-4daa-b8d5-fcef49e19a8e)

  * For multi node run: 
  ![image](https://github.com/user-attachments/assets/db65aca4-bad4-4dca-8e91-6f9e90b1ba94)

**3. New Command-Line Argument: `--timing`**

  * Enables timing code and reporting.
  * If used in conjunction with `args.distributed`, it will:
    * Automatically insert `barrier()` calls to synchronize nodes.
    * Print a consolidated multi-node timing report.

