### PR TITLE
Prioritized_sampling & prioritized_capacity

### DIFF
--- a/testing/test_replay_buffer.py
+++ b/testing/test_replay_buffer.py
@@ -133,7 +133,7 @@ def test_capacity_limit(simple_env, trajectories):
 
 
 def test_prioritized(simple_env, trajectories):
-    buffer = ReplayBuffer(simple_env, capacity=5, prioritized=True)
+    buffer = ReplayBuffer(simple_env, capacity=5, prioritized_capacity=True)
     buffer.add(trajectories)
 
     assert buffer.prioritized

--- a/tutorials/examples/train_graph_ring.py
+++ b/tutorials/examples/train_graph_ring.py
@@ -334,7 +334,7 @@ def main(args: Namespace):
     replay_buffer = ReplayBuffer(
         env,
         capacity=args.batch_size,
-        prioritized=True,
+        prioritized_capacity=True,
     )
 
     losses = []

--- a/tutorials/examples/train_hypergrid.py
+++ b/tutorials/examples/train_hypergrid.py
@@ -773,7 +773,7 @@ def main(args):  # noqa: C901
             replay_buffer = ReplayBuffer(
                 env,
                 capacity=args.replay_buffer_size,
-                prioritized=False,
+                prioritized_capacity=False,
             )
 
     gflownet = gflownet.to(device)


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

Current Prioritized Replay Buffer saves the trajectories with higher rewards, but then sample uniformly.
I added here the possibility to sample based on the reward.