### PR TITLE
Enable Experimental bf16 Support (Softmax in fp32)

### DIFF
--- a/src/gfn/estimators.py
+++ b/src/gfn/estimators.py
@@ -304,7 +304,13 @@ class DiscretePolicyEstimator(Estimator):
         if temperature != 1.0:
             logits /= temperature
 
-        probs = torch.softmax(logits, dim=-1)
+        # Set dtype only if default is lower precision (fp16 or bf16)
+        dtype = (
+            torch.float32
+            if torch.get_default_dtype() in (torch.float16, torch.bfloat16)
+            else None
+        )
+        probs = torch.softmax(logits, dim=-1, dtype=dtype)
 
         if epsilon != 0.0:
             uniform_dist_probs = torch.where(

--- a/src/gfn/utils/prob_calculations.py
+++ b/src/gfn/utils/prob_calculations.py
@@ -146,7 +146,9 @@ def get_trajectory_pfs(
             valid_actions.tensor
         )  # Using the actions sampled off-policy.
 
-        log_pf_trajectories[action_mask] = valid_log_pf_actions
+        log_pf_trajectories[action_mask] = valid_log_pf_actions.to(
+            log_pf_trajectories.dtype, copy=False
+        )
 
     assert log_pf_trajectories.shape == (
         trajectories.max_length,
@@ -218,7 +220,9 @@ def get_trajectory_pbs(
         valid_states, estimator_outputs
     ).log_prob(valid_actions.tensor)
 
-    log_pb_trajectories[action_mask] = valid_log_pb_actions
+    log_pb_trajectories[action_mask] = valid_log_pb_actions.to(
+        log_pb_trajectories.dtype, copy=False
+    )
 
     assert log_pb_trajectories.shape == (
         trajectories.max_length,

--- a/tutorials/examples/train_hypergrid.py
+++ b/tutorials/examples/train_hypergrid.py
@@ -1243,6 +1243,8 @@ def main(args):  # noqa: C901
 
 
 if __name__ == "__main__":
+    torch.set_default_dtype(torch.bfloat16)
+    print("Using dtype: ", torch.get_default_dtype())
     parser = ArgumentParser()
 
     # Machine setting.


### PR DESCRIPTION
PR checklist:
-->

- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

Adds initial support for running with `bf16` as the default dtype by:

- Forcing `softmax` to run in `fp32` when default dtype is `bf16`/`fp16`.

- Converting select tensors using `.to(torch.dtype)` for dtype compatibility.

> **Note:** This is an experimental change to enable `bf16 `testing only and is ~2.5× slower than `fp32`. **Not production-ready.**

### Additional Context:

- Attached log files show `bf16` and `fp16` errors observed without this fix.

- `fp16` is still unsupported with this change.

[bf16.run.out.4.4096000.2048.64.log](https://github.com/user-attachments/files/21542580/bf16.run.out.4.4096000.2048.64.log)
[fp16.run.out.4.4096000.2048.64.log](https://github.com/user-attachments/files/21542583/fp16.run.out.4.4096000.2048.64.log)
