### PR TITLE
Fix Formatting of Timing Information in Final Message

### DIFF
--- a/tutorials/examples/train_hypergrid.py
+++ b/tutorials/examples/train_hypergrid.py
@@ -1198,12 +1198,13 @@ def main(args):  # noqa: C901
 
     # Log the final timing results.
     if args.timing:
-        print("\n" + "=" * 80)
-        print("\n Timing information:")
-        if args.distributed:
-            print("-" * 80)
-            print("The below timing information is averaged across all ranks.")
-        print("=" * 80)
+        if my_rank == 0:
+            print("\n" + "=" * 80)
+            print("\n Timing information:")
+            if args.distributed:
+                print("-" * 80)
+                print("The below timing information is averaged across all ranks.")
+            print("=" * 80)
 
         if args.distributed:
             # Gather timing data from all ranks


### PR DESCRIPTION
PR checklist:
-->

- [ ] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [ ] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [ ] I've run pre-commit hooks locally

## Description

Ensure timing information is printed by a single rank to avoid messy duplicate output.