### PR TITLE
Add GAFN for hypergrid with sparse reward

### DIFF
--- a/docs/source/guides/creating_environments.md
+++ b/docs/source/guides/creating_environments.md
@@ -115,7 +115,7 @@ implemented and serves the purpose of uniquely identifying terminating states of
 the environment, which is useful for
 [tabular modules](https://github.com/gfnorg/torchgfn/tree/master/src/gfn/utils/modules.py).
 Other properties and functions can be implemented as well, such as the
-`log_partition` or the `true_dist_pmf` properties.
+`log_partition` or the `true_dist` properties.
 
 ## Environment Examples
 

--- a/docs/source/guides/example.md
+++ b/docs/source/guides/example.md
@@ -18,7 +18,7 @@ from gfn.samplers import Sampler
 from gfn.utils.modules import MLP  # is a simple multi-layer perceptron (MLP)
 
 # 1 - We define the environment.
-env = HyperGrid(ndim=4, height=8, R0=0.01)  # Grid of size 8x8x8x8
+env = HyperGrid(ndim=4, height=8)  # Grid of size 8x8x8x8
 preprocessor = KHotPreprocessor(ndim=env.ndim, height=env.height)
 
 # 2 - We define the needed modules (neural networks).
@@ -38,7 +38,7 @@ pf_estimator = DiscretePolicyEstimator(module_PF, env.n_actions, is_backward=Fal
 pb_estimator = DiscretePolicyEstimator(module_PB, env.n_actions, is_backward=True, preprocessor=preprocessor)
 
 # 4 - We define the GFlowNet.
-gfn = TBGFlowNet(logZ=0., pf=pf_estimator, pb=pb_estimator)  # We initialize logZ to 0
+gfn = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, init_logZ=0.0)  # We initialize logZ to 0
 
 # 5 - We define the sampler and the optimizer.
 sampler = Sampler(estimator=pf_estimator)  # We use an on-policy sampler, based on the forward policy
@@ -75,7 +75,7 @@ from gfn.samplers import Sampler
 from gfn.utils.modules import MLP  # MLP is a simple multi-layer perceptron (MLP)
 
 # 1 - We define the environment.
-env = HyperGrid(ndim=4, height=8, R0=0.01)  # Grid of size 8x8x8x8
+env = HyperGrid(ndim=4, height=8)  # Grid of size 8x8x8x8
 preprocessor = KHotPreprocessor(ndim=env.ndim, height=env.height)
 
 # 2 - We define the needed modules (neural networks).

--- a/src/gfn/env.py
+++ b/src/gfn/env.py
@@ -401,7 +401,7 @@ class Env(ABC):
         )
 
     @property
-    def true_dist_pmf(self) -> torch.Tensor:
+    def true_dist(self) -> torch.Tensor:
         """Optional method to return the true distribution.
 
         Returns:

--- a/src/gfn/gflownet/trajectory_balance.py
+++ b/src/gfn/gflownet/trajectory_balance.py
@@ -41,7 +41,8 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
         self,
         pf: Estimator,
         pb: Estimator,
-        logZ: float | ScalarEstimator = 0.0,
+        logZ: nn.Parameter | ScalarEstimator | None = None,
+        init_logZ: float = 0.0,
         log_reward_clip_min: float = -float("inf"),
     ):
         """Initializes a TBGFlowNet instance.
@@ -51,18 +52,12 @@ class TBGFlowNet(TrajectoryBasedGFlowNet):
             pb: The backward policy estimator.
             logZ: A learnable parameter or a ScalarEstimator instance (for
                 conditional GFNs).
+            init_logZ: The initial value for the logZ parameter (used if logZ is None).
             log_reward_clip_min: If finite, clips log rewards to this value.
         """
         super().__init__(pf, pb)
 
-        if isinstance(logZ, float):
-            self.logZ = nn.Parameter(torch.tensor(logZ))
-        else:
-            assert isinstance(
-                logZ, ScalarEstimator
-            ), "logZ must be either float or a ScalarEstimator"
-            self.logZ = logZ
-
+        self.logZ = logZ or nn.Parameter(torch.tensor(init_logZ))
         self.log_reward_clip_min = log_reward_clip_min
 
     def logz_named_parameters(self) -> dict[str, torch.Tensor]:

--- a/src/gfn/gym/bitSequence.py
+++ b/src/gfn/gym/bitSequence.py
@@ -704,7 +704,7 @@ class BitSequence(DiscreteEnv):
         return 2 ** (self.seq_size + 1) - 1
 
     @property
-    def true_dist_pmf(self) -> torch.Tensor:
+    def true_dist(self) -> torch.Tensor:
         """Returns the true probability mass function of the reward distribution."""
         states = self.terminating_states
         rewards = self.reward(states)

--- a/src/gfn/gym/discrete_ebm.py
+++ b/src/gfn/gym/discrete_ebm.py
@@ -297,7 +297,7 @@ class DiscreteEBM(DiscreteEnv):
         return self.states_from_tensor(all_states)
 
     @property
-    def true_dist_pmf(self) -> torch.Tensor:
+    def true_dist(self) -> torch.Tensor:
         """Returns the true probability mass function of the reward distribution."""
         true_dist = self.reward(self.terminating_states)
         return true_dist / true_dist.sum()

--- a/src/gfn/gym/helpers/hypergrid/rewards.py
+++ b/src/gfn/gym/helpers/hypergrid/rewards.py
@@ -1,0 +1,114 @@
+import itertools
+from abc import ABC, abstractmethod
+from typing import Callable
+
+import torch
+
+EPS = 1e-12
+
+
+def get_reward_fn(
+    reward_fn_str: str, height: int, ndim: int, reward_fn_kwargs: dict | None = None
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Get the reward function for the HyperGrid environment."""
+    reward_fn_kwargs = reward_fn_kwargs or {}
+    if reward_fn_str == "original":
+        return OriginalReward(height, ndim, **reward_fn_kwargs)
+    elif reward_fn_str == "cosine":
+        return CosineReward(height, ndim, **reward_fn_kwargs)
+    elif reward_fn_str == "sparse":
+        return SparseReward(height, ndim, **reward_fn_kwargs)
+    elif reward_fn_str == "deceptive":
+        return DeceptiveReward(height, ndim, **reward_fn_kwargs)
+    else:
+        raise ValueError(f"Invalid reward function string: {reward_fn_str}")
+
+
+class GridReward(ABC):
+    """Base class for reward functions that can be pickled."""
+
+    def __init__(self, height: int, ndim: int, **kwargs):
+        self.height = height
+        self.ndim = ndim
+        self.kwargs = kwargs
+
+    @abstractmethod
+    def __call__(self, states_tensor: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class OriginalReward(GridReward):
+    """The reward function from the original GFlowNet paper (Bengio et al., 2021;
+    https://arxiv.org/abs/2106.04399)."""
+
+    def __call__(self, states_tensor: torch.Tensor) -> torch.Tensor:
+        R0 = self.kwargs.get("R0", 0.1)
+        R1 = self.kwargs.get("R1", 0.5)
+        R2 = self.kwargs.get("R2", 2.0)
+
+        ax = abs(states_tensor / (self.height - 1) - 0.5)
+        return (
+            R0
+            + (0.25 + EPS < ax).prod(-1) * R1
+            + ((0.3 + EPS < ax) * (ax < 0.4 + EPS)).prod(-1) * R2
+        )
+
+
+class CosineReward(GridReward):
+    """Cosine reward function."""
+
+    def __call__(self, states_tensor: torch.Tensor) -> torch.Tensor:
+        R0 = self.kwargs.get("R0", 0.1)
+        R1 = self.kwargs.get("R1", 0.5)
+
+        ax = abs(states_tensor / (self.height - 1) - 0.5)
+        pdf_input = ax * 5
+        pdf = 1.0 / (2 * torch.pi) ** 0.5 * torch.exp(-(pdf_input**2) / 2)
+        reward = R0 + ((torch.cos(ax * 50) + 1) * pdf).prod(-1) * R1
+        return reward
+
+
+class SparseReward(GridReward):
+    """Sparse reward function from the GAFN paper (Pan et al., 2022;
+    https://arxiv.org/abs/2210.03308)."""
+
+    def __init__(self, height: int, ndim: int, **kwargs):
+        super().__init__(height, ndim, **kwargs)
+        targets = []
+        for number_of_1s in range(ndim):
+            targets.extend(
+                itertools.permutations(
+                    [1] * number_of_1s + [self.height - 2] * (self.ndim - number_of_1s)
+                )
+            )
+        self.targets = torch.tensor(list(set(targets)), dtype=torch.long)
+
+    def __call__(self, states_tensor: torch.Tensor) -> torch.Tensor:
+        self.targets = self.targets.to(states_tensor.device)
+        reward = (
+            (states_tensor.unsqueeze(1) == self.targets.unsqueeze(0)).prod(-1).sum(-1)
+        ) + 1e-12  # Avoid log(0)
+        return reward
+
+
+class DeceptiveReward(GridReward):
+    """Deceptive reward function from the Adaptive Teachers paper (Kim et al., 2025;
+    https://arxiv.org/abs/2410.01432).
+
+    Note that the reward definition in the paper (eq. (9)) is incorrect, and we follow
+    the official implementation (https://github.com/alstn12088/adaptive-teacher/blob/8cfcb2298fce3f46eb36ead03791eeee75b7d066/grid/env.py#L27)
+    while modifying it to use EPS = 1e-12 to handle inequalities with floating points.
+    """
+
+    def __call__(self, states_tensor: torch.Tensor) -> torch.Tensor:
+        R0 = self.kwargs.get("R0", 1e-5)
+        R1 = self.kwargs.get("R1", 0.1)
+        R2 = self.kwargs.get("R2", 2.0)
+
+        ax = abs(states_tensor / (self.height - 1) - 0.5)
+        return (
+            R0
+            + R1
+            - (0.1 + EPS < ax).prod(-1) * R1
+            + ((0.3 + EPS < ax) * (ax < 0.4 + EPS)).prod(-1) * R2
+        )

--- a/src/gfn/gym/hypergrid.py
+++ b/src/gfn/gym/hypergrid.py
@@ -14,6 +14,7 @@ import torch
 
 from gfn.actions import Actions
 from gfn.env import DiscreteEnv
+from gfn.gym.helpers.hypergrid.rewards import get_reward_fn
 from gfn.states import DiscreteStates
 
 if platform.system() == "Windows":
@@ -55,67 +56,54 @@ class HyperGrid(DiscreteEnv):
     Attributes:
         ndim: The dimension of the grid.
         height: The height of the grid.
-        R0: The reward parameter R0.
-        R1: The reward parameter R1.
-        R2: The reward parameter R2.
-        reward_cos: Whether to use the cosine reward.
+        reward_fn: The reward function.
         calculate_partition: Whether to calculate the log partition function.
-        calculate_all_states: Whether to store all states.
-        scale_factor: The scale factor for the reward.
+        store_all_states: Whether to store all states.
     """
 
     def __init__(
         self,
         ndim: int = 2,
         height: int = 4,
-        R0: float = 0.1,
-        R1: float = 0.5,
-        R2: float = 2.0,
-        reward_cos: bool = False,
+        reward_fn_str: str = "original",
+        reward_fn_kwargs: dict | None = None,
         device: Literal["cpu", "cuda"] | torch.device = "cpu",
         calculate_partition: bool = False,
-        calculate_all_states: bool = False,
+        store_all_states: bool = False,
     ):
         """Initializes the HyperGrid environment.
 
         Args:
             ndim: The dimension of the grid.
             height: The height of the grid.
-            R0: The reward parameter R0.
-            R1: The reward parameter R1.
-            R2: The reward parameter R2.
-            reward_cos: Whether to use the cosine reward.
+            reward_fn_str: The reward function string to use.
+            reward_fn_kwargs: The keyword arguments for the reward function.
             device: The device to use.
             calculate_partition: Whether to calculate the log partition function.
-            calculate_all_states: Whether to store all states.
+            store_all_states: Whether to store all states. If True, the true distribution
+                can be accessed via the `true_dist` property.
         """
         if height <= 4:
             warnings.warn("+ Warning: height <= 4 can lead to unsolvable environments.")
 
         self.ndim = ndim
         self.height = height
-        self.R0 = R0
-        self.R1 = R1
-        self.R2 = R2
-        self.reward_cos = reward_cos
-        self._all_states = None  # Populated optionally in init.
+        self.reward_fn = get_reward_fn(reward_fn_str, height, ndim, reward_fn_kwargs)
+        self._all_states_tensor = None  # Populated optionally in init.
         self._log_partition = None  # Populated optionally in init.
-        self._true_dist_pmf = None  # Populated at first request.
+        self._true_dist = None  # Populated at first request.
         self.calculate_partition = calculate_partition
-        self.calculate_all_states = calculate_all_states
+        self.store_all_states = store_all_states
 
         # Pre-computes these values when printing.
-        if self.calculate_all_states:
-            self._calculate_all_states_tensor()
-            assert self._all_states is not None
-            print(f"+ Environment has {len(self._all_states)} states")
+        if self.store_all_states:
+            self._store_all_states_tensor()
+            assert self._all_states_tensor is not None
+            print(f"+ Environment has {len(self._all_states_tensor)} states")
+
         if self.calculate_partition:
             self._calculate_log_partition()
             print(f"+ Environment log partition is {self._log_partition}")
-
-        # This scale is used to stabilize some calculations.
-        # self.scale_factor = smallest_multiplier_to_integers([R0, R1, R2])
-        self.scale_factor = 1
 
         if isinstance(device, str):
             device = torch.device(device)
@@ -132,7 +120,7 @@ class HyperGrid(DiscreteEnv):
             state_shape=state_shape,
             sf=sf,
         )
-        self.States: type[DiscreteStates] = self.States
+        self.States: type[DiscreteStates] = self.States  # for type checking
 
     def update_masks(self, states: DiscreteStates) -> None:
         """Updates the masks of the states.
@@ -195,7 +183,7 @@ class HyperGrid(DiscreteEnv):
         assert new_states_tensor.shape == states.tensor.shape
         return self.States(new_states_tensor)
 
-    def reward(self, final_states: DiscreteStates | torch.Tensor) -> torch.Tensor:
+    def reward(self, states: DiscreteStates) -> torch.Tensor:
         r"""Computes the reward for a batch of final states.
 
         In the normal setting, the reward is:
@@ -209,35 +197,10 @@ class HyperGrid(DiscreteEnv):
         Returns:
             The reward of the final states.
         """
-        assert isinstance(
-            final_states, DiscreteStates | torch.Tensor
-        ), f"final_states is {type(final_states)}"
-        if isinstance(final_states, DiscreteStates):
-            final_states_raw = final_states.tensor
-        else:
-            final_states_raw = final_states
-
-        R0, R1, R2 = (self.R0, self.R1, self.R2)
-        ax = abs(final_states_raw / (self.height - 1) - 0.5)
-
-        if not self.reward_cos:
-            reward = (
-                R0 + (0.25 < ax).prod(-1) * R1 + ((0.3 < ax) * (ax < 0.4)).prod(-1) * R2
-            )
-        else:
-            pdf_input = ax * 5
-            pdf = 1.0 / (2 * torch.pi) ** 0.5 * torch.exp(-(pdf_input**2) / 2)
-            reward = R0 + ((torch.cos(ax * 50) + 1) * pdf).prod(-1) * R1
-
-        if isinstance(final_states, DiscreteStates):
-            assert (
-                reward.shape == final_states.batch_shape
-            ), f"reward.shape is {reward.shape} and final_states.batch_shape is {final_states.batch_shape}"
-        else:
-            n_dims = len(reward.shape)
-            assert (
-                reward.shape == final_states.shape[:n_dims]
-            ), f"reward.shape is {reward.shape} and final_states.shape is {final_states.shape}"
+        reward = self.reward_fn(states.tensor)
+        assert (
+            reward.shape == states.batch_shape
+        ), f"reward.shape is {reward.shape} and states.batch_shape is {states.batch_shape}"
         return reward
 
     def get_states_indices(self, states: DiscreteStates | torch.Tensor) -> torch.Tensor:
@@ -299,6 +262,12 @@ class HyperGrid(DiscreteEnv):
         """
 
         if self._log_partition is None and self.calculate_partition:
+            if self._all_states_tensor is not None:
+                self._log_partition = (
+                    self.reward_fn(self._all_states_tensor).sum().log().item()
+                )
+                return
+
             # The # of possible combinations (with repetition) of
             # numbers, where each
             # number can be any integer from 0 to
@@ -317,7 +286,7 @@ class HyperGrid(DiscreteEnv):
                 batch_size,
             ):
                 batch = torch.LongTensor(list(batch))
-                rewards = self.reward(
+                rewards = self.reward_fn(
                     batch
                 )  # Operates on raw tensors due to multiprocessing.
                 total_reward += rewards.sum().item()  # Accumulate.
@@ -336,24 +305,24 @@ class HyperGrid(DiscreteEnv):
 
             self._log_partition = total_log_reward
 
-    def _calculate_all_states_tensor(self, batch_size: int = 20_000):
-        """Enumerates all states of the complete hypergrid.
+    def _store_all_states_tensor(self, batch_size: int = 20_000):
+        """Enumerates all states_tensor of the complete hypergrid.
 
         Args:
             batch_size: The batch size to use for the calculation.
         """
-        if self._all_states is None and self.calculate_all_states:
+        if self._all_states_tensor is None:
             start_time = time()
-            all_states = []
+            all_states_tensor = []
 
             for batch in self._generate_combinations_in_batches(
                 self.ndim,
                 self.height - 1,  # Handles 0 indexing.
                 batch_size,
             ):
-                all_states.append(torch.LongTensor(list(batch)))
+                all_states_tensor.append(torch.LongTensor(list(batch)))
 
-            all_states = torch.cat(all_states, dim=0)
+            all_states_tensor = torch.cat(all_states_tensor, dim=0)
             end_time = time()
 
             print(
@@ -362,20 +331,20 @@ class HyperGrid(DiscreteEnv):
                 )
             )
 
-            self._all_states = all_states
+            self._all_states_tensor = all_states_tensor
 
     @property
-    def true_dist_pmf(self) -> torch.Tensor | None:
+    def true_dist(self) -> torch.Tensor | None:
         """Returns the pmf over all states in the hypergrid."""
-        if self._true_dist_pmf is None and self.calculate_all_states:
+        if self._true_dist is None and self.all_states is not None:
             assert torch.all(
                 self.get_states_indices(self.all_states)
                 == torch.arange(self.n_states, device=self.device)
             )
-            self._true_dist_pmf = self.reward(self.all_states)
-            self._true_dist_pmf /= self._true_dist_pmf.sum()
+            self._true_dist = self.reward(self.all_states)
+            self._true_dist /= self._true_dist.sum()
 
-        return self._true_dist_pmf
+        return self._true_dist
 
     def all_indices(self) -> List[Tuple[int, ...]]:
         """Generate all possible indices for the grid.
@@ -399,22 +368,23 @@ class HyperGrid(DiscreteEnv):
         return self._log_partition
 
     @property
-    def all_states(self) -> DiscreteStates:
+    def all_states(self) -> DiscreteStates | None:
         """Returns a tensor of all hypergrid states as a `DiscreteStates` instance."""
-        if self.calculate_all_states and not isinstance(self._all_states, torch.Tensor):
-            self._calculate_all_states_tensor()
+        if self._all_states_tensor is None:
+            if not self.store_all_states:
+                return None
+            self._store_all_states_tensor()
 
-        assert self._all_states is not None
-        all_states = self.States(self._all_states)
-        assert isinstance(all_states, DiscreteStates)
+        assert self._all_states_tensor is not None
+        all_states = self.States(self._all_states_tensor)
         return all_states
 
     @property
-    def terminating_states(self) -> DiscreteStates:
+    def terminating_states(self) -> DiscreteStates | None:
         """Returns all terminating states of the environment."""
         return self.all_states
 
-    # Helper methods for enumerating all possible statxes.
+    # Helper methods for enumerating all possible states.
     def _generate_combinations_chunk(self, numbers, n, start, end):
         """Generate combinations with replacement for the specified range."""
         # islice accesses a subset of the full iterator - each job does unique work.

--- a/src/gfn/utils/modules.py
+++ b/src/gfn/utils/modules.py
@@ -22,7 +22,7 @@ class MLP(nn.Module):
         output_dim: int,
         hidden_dim: int = 256,
         n_hidden_layers: Optional[int] = 2,
-        activation_fn: Optional[Literal["relu", "tanh", "elu"]] = "relu",
+        activation_fn: Optional[Literal["relu", "leaky_relu", "tanh", "elu"]] = "relu",
         trunk: Optional[nn.Module] = None,
         add_layer_norm: bool = False,
     ):
@@ -52,6 +52,8 @@ class MLP(nn.Module):
                 activation = nn.ELU
             elif activation_fn == "relu":
                 activation = nn.ReLU
+            elif activation_fn == "leaky_relu":
+                activation = nn.LeakyReLU
             elif activation_fn == "tanh":
                 activation = nn.Tanh
 

--- a/src/gfn/utils/training.py
+++ b/src/gfn/utils/training.py
@@ -12,14 +12,14 @@ from gfn.samplers import Trajectories
 from gfn.states import DiscreteStates
 
 
-def get_terminating_state_dist_pmf(
+def get_terminating_state_dist(
     env: DiscreteEnv,
     states: DiscreteStates,
 ) -> torch.Tensor:
     """Computes the empirical distribution of the terminating states.
 
     Args:
-        env: The environment.
+        env: The DiscreteEnv instance.
         states: The states to compute the distribution of.
 
     Returns:
@@ -67,11 +67,11 @@ def validate(
     """
 
     true_logZ = env.log_partition
-    true_dist_pmf = env.true_dist_pmf
-    if isinstance(true_dist_pmf, torch.Tensor):
-        true_dist_pmf = true_dist_pmf.cpu()
+    true_dist = env.true_dist
+    if isinstance(true_dist, torch.Tensor):
+        true_dist = true_dist.cpu()
     else:
-        # The environment does not implement a true_dist_pmf property, nor a log_partition property
+        # The environment does not implement a true_dist property, nor a log_partition property
         # We cannot validate the gflownet
         return {}, visited_terminating_states
 
@@ -88,10 +88,8 @@ def validate(
         # Only keep the most recent n_validation_samples states.
         sampled_terminating_states = visited_terminating_states[-n_validation_samples:]
 
-    final_states_dist_pmf = get_terminating_state_dist_pmf(
-        env, sampled_terminating_states
-    )
-    l1_dist = (final_states_dist_pmf - true_dist_pmf).abs().mean().item()
+    final_states_dist = get_terminating_state_dist(env, sampled_terminating_states)
+    l1_dist = (final_states_dist - true_dist).abs().mean().item()
     validation_info = {"l1_dist": l1_dist}
     if logZ is not None:
         validation_info["logZ_diff"] = abs(logZ - true_logZ)

--- a/testing/test_environments.py
+++ b/testing/test_environments.py
@@ -298,9 +298,10 @@ def test_get_grid():
     NDIM = 2
 
     env = HyperGrid(
-        height=HEIGHT, ndim=NDIM, calculate_all_states=True, calculate_partition=True
+        height=HEIGHT, ndim=NDIM, store_all_states=True, calculate_partition=True
     )
     all_states = env.all_states
+    assert all_states is not None
 
     assert all_states.batch_shape == (HEIGHT**2,)
     assert all_states.state_shape == (NDIM,)

--- a/tutorials/examples/mRNA_design/main.py
+++ b/tutorials/examples/mRNA_design/main.py
@@ -58,7 +58,7 @@ def main(args):
     )
 
     # 2. Create the gflownet.
-    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, logZ=0.0).to(device)
+    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, init_logZ=0.0).to(device)
     sampler = Sampler(estimator=pf_estimator)
 
     # 3. Create the optimizer and Lr scheduler

--- a/tutorials/examples/test_scripts.py
+++ b/tutorials/examples/test_scripts.py
@@ -58,7 +58,7 @@ class DiscreteEBMArgs(CommonArgs):
 @dataclass
 class HypergridArgs(CommonArgs):
     back_ratio: float = 0.5
-    calculate_all_states: bool = True
+    store_all_states: bool = True
     calculate_partition: bool = True
     distributed: bool = False
     diverse_replay_buffer: bool = False

--- a/tutorials/examples/train_hypergrid_gafn.py
+++ b/tutorials/examples/train_hypergrid_gafn.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python
+r"""
+A version of GFlowNet training that implements Generative Augmented Flow Networks (GAFN,
+https://arxiv.org/abs/2210.03308). It is a variant of GFlowNet that introduces intrinsic
+rewards to the GFlowNet training. It relies on the Random Network Distillation (RND,
+https://arxiv.org/abs/1810.12894) to define intrinsic rewards.
+
+Example usage:
+python train_hypergrid_gafn.py --ndim 2 --height 8 --rnd_reward_scale 0.005
+
+Key features:
+- Implements GAFN training
+- Uses RND to define intrinsic rewards
+- Based on TB loss like the train_hypergrid_simple.py example
+"""
+
+import argparse
+from typing import cast
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+
+from gfn.containers import Trajectories
+from gfn.env import Env
+from gfn.estimators import DiscretePolicyEstimator, Estimator, ScalarEstimator
+from gfn.gflownet import TBGFlowNet
+from gfn.gym import HyperGrid
+from gfn.preprocessors import KHotPreprocessor, Preprocessor
+from gfn.samplers import Sampler
+from gfn.states import DiscreteStates, States
+from gfn.utils.common import set_seed
+from gfn.utils.modules import MLP, DiscreteUniform
+from gfn.utils.training import validate
+
+
+class RND(nn.Module):
+    """
+    Random Network Distillation (RND) module. It is a module that predicts the random
+    target net from the state.
+    """
+
+    def __init__(
+        self,
+        state_dim: int,
+        preprocessor: Preprocessor,
+        reward_scale: float = 0.1,
+        loss_scale: float = 0.1,
+        hidden_dim: int = 256,
+        s_latent_dim: int = 128,
+    ) -> None:
+        """
+        Random Network Distillation (RND) module. It is a module that predicts the
+        random target net from the state.
+
+        Args:
+            state_dim: The dimension of the state space.
+            preprocessor: The preprocessor for the state space.
+            reward_scale: The scale of the reward.
+            loss_scale: The scale of the loss.
+            hidden_dim: The dimension of the hidden layer.
+            s_latent_dim: The dimension of the latent state.
+        """
+        super().__init__()
+
+        self.preprocessor = preprocessor
+        self.reward_scale = reward_scale
+        self.loss_scale = loss_scale
+
+        self.random_target_net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.LeakyReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.LeakyReLU(),
+            nn.Linear(hidden_dim, s_latent_dim),
+        )
+
+        # Note the same architecture as the random target net
+        self.predictor_net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.LeakyReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.LeakyReLU(),
+            nn.Linear(hidden_dim, s_latent_dim),
+        )
+
+        self.reward_scale = reward_scale
+
+    def forward(self, states: States) -> torch.Tensor:
+        l2_error = torch.zeros(states.batch_shape, device=states.device)
+
+        valid_states = states[~states.is_sink_state]
+
+        states_tensor = self.preprocessor(valid_states).to(l2_error.dtype)
+        random_target_feature = self.random_target_net(states_tensor).detach()
+        predictor_feature = self.predictor_net(states_tensor)
+
+        l2_error[~states.is_sink_state] = torch.norm(
+            random_target_feature - predictor_feature, dim=-1, p=2
+        )
+        return l2_error
+
+    def compute_intrinsic_reward(self, states: States) -> torch.Tensor:
+        l2_error = self(states)
+        return l2_error.detach() * self.reward_scale
+
+    def compute_rnd_loss(self, states: States) -> torch.Tensor:
+        l2_error = self(states)
+        l2_error = l2_error.sum(dim=0) / (~states.is_sink_state).sum(dim=0)
+        return l2_error.mean() * self.loss_scale
+
+
+class TBGAFN(TBGFlowNet):
+    """
+    Generative Augmented Flow Networks based on the Trajectory Balance loss.
+
+    Args:
+        pf: The forward policy estimator.
+    """
+
+    def __init__(
+        self,
+        pf: Estimator,
+        pb: Estimator,
+        rnd: RND,
+        logZ: nn.Parameter | ScalarEstimator | None = None,
+        init_logZ: float = 0.0,
+        use_edge_ri: bool = False,
+        flow_estimator: ScalarEstimator | None = None,
+        log_reward_clip_min: float = -float("inf"),
+    ):
+        """Initializes a TBGFlowNet instance.
+
+        Args:
+            pf: The forward policy estimator.
+            pb: The backward policy estimator.
+            rnd: The RND module.
+            logZ: A learnable parameter or a ScalarEstimator instance (for
+                conditional GFNs).
+            init_logZ: The initial value for the logZ parameter (used if logZ is None).
+            use_edge_ri: Whether to use edge-based intrinsic rewards.
+            flow_estimator: The flow estimator, required if use_edge_ri is True.
+            log_reward_clip_min: If finite, clips log rewards to this value.
+        """
+        super().__init__(pf, pb, logZ, init_logZ, log_reward_clip_min)
+        self.rnd = rnd
+        self.use_edge_ri = use_edge_ri
+        if use_edge_ri and flow_estimator is None:
+            raise ValueError("flow_estimator is required if use_edge_ri is True")
+        self.flow_estimator = flow_estimator
+
+    def rnd_parameters(self) -> list[torch.Tensor]:
+        return list(self.rnd.parameters())
+
+    def flow_parameters(self) -> list[torch.Tensor]:
+        if self.flow_estimator is None:
+            return []
+        return list(
+            [v for k, v in self.flow_estimator.named_parameters() if "trunk" not in k]
+        )
+
+    def get_scores(
+        self, trajectories: Trajectories, recalculate_all_logprobs: bool = True
+    ) -> torch.Tensor:
+        """Computes Trajectory Balance scores with intrinsic rewards for a batch of
+        trajectories.
+
+        Args:
+            trajectories: The Trajectories object to evaluate.
+            recalculate_all_logprobs: Whether to re-evaluate all logprobs.
+
+        Returns:
+            A tensor of shape (n_trajectories,) containing the scores for each trajectory.
+        """
+        log_pf_trajectories, log_pb_trajectories = self.get_pfs_and_pbs(
+            trajectories, recalculate_all_logprobs=recalculate_all_logprobs
+        )
+        log_rewards = trajectories.log_rewards
+        assert log_rewards is not None
+        if self.use_edge_ri:
+            # Use the edge-based intrinsic rewards.
+            # Note that the original implementation uses the edge-based intrinsic
+            # rewards (eq. (4) of the original paper) by default rather than the joint
+            # intermediate reward (eq. (6)).
+            # Also, they define r(s_t \to s_{t+1}) = r(s_{t+1}) and here we follow
+            # this definition.
+            assert self.flow_estimator is not None
+            log_state_flows = torch.zeros(
+                trajectories.states.tensor.shape[:-1],
+                device=trajectories.states.device,
+            )
+            # Note: These two lines below may require a lot of memory if trajectory length
+            # is very long.
+            log_state_flows[~trajectories.states.is_sink_state] = self.flow_estimator(
+                trajectories.states[~trajectories.states.is_sink_state]
+            ).squeeze(-1)
+            edge_ri = self.rnd.compute_intrinsic_reward(trajectories.states)
+            # shape: (max_length, n_trajectories)
+            terminal_ri = edge_ri[
+                trajectories.terminating_idx - 1,
+                torch.arange(trajectories.n_trajectories, device=edge_ri.device),
+            ]  # shape: (n_trajectories,)
+            _terminal_part = torch.stack(
+                [log_rewards, terminal_ri.log()], dim=0
+            ).logsumexp(dim=0)
+            _interm_part = torch.stack(
+                [log_pb_trajectories, edge_ri[1:].log() - log_state_flows[1:]], dim=0
+            ).logsumexp(dim=0)
+            log_target = _terminal_part + _interm_part.sum(dim=0)
+        else:
+            # Use the state-based intrinsic rewards.
+            # We use only the terminal states to compute the intrinsic rewards.
+            # This isn't from the original paper, but it's a special case of the joint
+            # intermediate reward (eq. (6)) with the edge-based intrinsic rewards
+            # being zero, i.e., r(s_t \to s_{t+1}) = 0 for all t.
+            terminal_ri = self.rnd.compute_intrinsic_reward(
+                trajectories.terminating_states
+            )  # shape: (n_trajectories,)
+            _terminal_part = torch.stack(
+                [log_rewards, terminal_ri.log()], dim=0
+            ).logsumexp(dim=0)
+            log_target = _terminal_part + log_pb_trajectories.sum(dim=0)
+
+        scores = log_pf_trajectories.sum(dim=0) - log_target
+        return scores
+
+    def loss(
+        self,
+        env: Env,
+        trajectories: Trajectories,
+        recalculate_all_logprobs: bool = True,
+        reduction: str = "mean",
+    ) -> torch.Tensor:
+        loss = super().loss(env, trajectories, recalculate_all_logprobs, reduction)
+        rnd_loss = self.rnd.compute_rnd_loss(trajectories.states)
+        return loss + rnd_loss
+
+
+def main(args):
+    set_seed(args.seed)
+    device = torch.device(
+        "cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu"
+    )
+
+    # Setup the Environment.
+    env = HyperGrid(
+        ndim=args.ndim,
+        height=args.height,
+        reward_fn_str="sparse",
+        device=device,
+        calculate_partition=True,
+        store_all_states=True,
+    )
+    preprocessor = KHotPreprocessor(height=env.height, ndim=env.ndim)
+
+    # Build the GFlowNet.
+    module_PF = MLP(
+        input_dim=preprocessor.output_dim,
+        output_dim=env.n_actions,
+        activation_fn="leaky_relu",  # use leaky relu as in the original GAFN paper
+    )
+    if not args.uniform_pb:
+        module_PB = MLP(
+            input_dim=preprocessor.output_dim,
+            output_dim=env.n_actions - 1,
+            trunk=module_PF.trunk,
+        )
+    else:
+        module_PB = DiscreteUniform(output_dim=env.n_actions - 1)
+    pf_estimator = DiscretePolicyEstimator(
+        module_PF, env.n_actions, preprocessor=preprocessor, is_backward=False
+    )
+    pb_estimator = DiscretePolicyEstimator(
+        module_PB, env.n_actions, preprocessor=preprocessor, is_backward=True
+    )
+
+    rnd = RND(
+        state_dim=preprocessor.output_dim,
+        preprocessor=preprocessor,
+        reward_scale=args.rnd_reward_scale,
+        loss_scale=args.rnd_loss_scale,
+        hidden_dim=args.rnd_hidden_dim,
+        s_latent_dim=args.rnd_s_latent_dim,
+    )
+    flow_estimator = None
+    if args.use_edge_ri:
+        flow_estimator = ScalarEstimator(
+            module=MLP(
+                input_dim=preprocessor.output_dim,
+                output_dim=1,
+                trunk=module_PF.trunk,
+            ),
+            preprocessor=preprocessor,
+        )
+    gflownet = TBGAFN(
+        pf=pf_estimator,
+        pb=pb_estimator,
+        init_logZ=0.0,
+        rnd=rnd,
+        use_edge_ri=args.use_edge_ri,
+        flow_estimator=flow_estimator,
+    )
+
+    # Feed pf to the sampler.
+    sampler = Sampler(estimator=pf_estimator)
+
+    # Move the gflownet to the GPU.
+    gflownet = gflownet.to(device)
+
+    # Policy parameters have their own LR. Log Z gets dedicated learning rate
+    # (typically higher).
+    optimizer = torch.optim.Adam(gflownet.pf_pb_parameters(), lr=args.lr)
+    optimizer.add_param_group({"params": gflownet.logz_parameters(), "lr": args.lr_logz})
+    optimizer.add_param_group({"params": gflownet.rnd_parameters(), "lr": args.lr_rnd})
+    if args.use_edge_ri:
+        optimizer.add_param_group({"params": gflownet.flow_parameters(), "lr": args.lr})
+
+    validation_info = {"l1_dist": float("inf")}
+    visited_terminating_states = env.states_from_batch_shape((0,))
+    for it in (pbar := tqdm(range(args.n_iterations), dynamic_ncols=True)):
+        trajectories = sampler.sample_trajectories(
+            env,
+            n=args.batch_size,
+            save_logprobs=True,
+            save_estimator_outputs=False,
+        )
+        visited_terminating_states.extend(
+            cast(DiscreteStates, trajectories.terminating_states)
+        )
+
+        optimizer.zero_grad()
+        loss = gflownet.loss(env, trajectories, recalculate_all_logprobs=False)
+        loss.backward()
+        optimizer.step()
+        if (it + 1) % args.validation_interval == 0:
+            validation_info, _ = validate(
+                env,
+                gflownet,
+                args.validation_samples,
+                visited_terminating_states,
+            )
+            print(f"Iter {it + 1}: L1 distance {validation_info['l1_dist']:.8f}")
+            print(
+                f"RND loss: {gflownet.rnd.compute_rnd_loss(trajectories.states).item()}"
+            )
+
+        pbar.set_postfix({"loss": loss.item()})
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no_cuda", action="store_true", help="Prevent CUDA usage")
+    parser.add_argument(
+        "--ndim", type=int, default=2, help="Number of dimensions in the environment"
+    )
+    parser.add_argument(
+        "--height", type=int, default=8, help="Height of the environment"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=1e-3,
+        help="Learning rate for the estimators' modules",
+    )
+    parser.add_argument(
+        "--lr_logz",
+        type=float,
+        default=1e-1,
+        help="Learning rate for the logZ parameter",
+    )
+    parser.add_argument(
+        "--uniform_pb", action="store_true", help="Use a uniform backward policy"
+    )
+    parser.add_argument(
+        "--n_iterations", type=int, default=1000, help="Number of iterations"
+    )
+    parser.add_argument(
+        "--validation_interval", type=int, default=100, help="Validation interval"
+    )
+    parser.add_argument(
+        "--validation_samples",
+        type=int,
+        default=100000,
+        help="Number of validation samples to use to evaluate the probability mass function.",
+    )
+    parser.add_argument("--batch_size", type=int, default=16, help="Batch size")
+
+    # GAFN & RND parameters.
+    parser.add_argument(
+        "--use_edge_ri",
+        action="store_true",
+        help="Use edge-based intrinsic rewards",
+    )
+    parser.add_argument(
+        "--lr_rnd",
+        type=float,
+        default=1e-3,
+        help="Learning rate for the RND module",
+    )
+    parser.add_argument(
+        "--rnd_reward_scale",
+        type=float,
+        default=0.1,
+        help="The scale of the reward for the RND module",
+    )
+    parser.add_argument(
+        "--rnd_loss_scale",
+        type=float,
+        default=1.0,
+        help="The scale of the loss for the RND module",
+    )
+    parser.add_argument(
+        "--rnd_hidden_dim",
+        type=int,
+        default=256,
+        help="The dimension of the hidden layer for the RND module",
+    )
+    parser.add_argument(
+        "--rnd_s_latent_dim",
+        type=int,
+        default=128,
+        help="The dimension of the latent state for the RND module",
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/tutorials/examples/train_hypergrid_local_search.py
+++ b/tutorials/examples/train_hypergrid_local_search.py
@@ -4,17 +4,16 @@ A version of GFlowNet training that implements local search sampling strategies 
 HyperGrid environment. This demonstrates how to use more sophisticated sampling
 approaches like local search and Metropolis-Hastings.
 
-For usage see train_hypergrid_local_search.py -h
-
 Example usage:
-python train_hypergrid_local_search.py --ndim 2 --height 8 --n_local_search_loops 2 --back_ratio 0.5 --use_metropolis_hastings
+python train_hypergrid_local_search.py --ndim 2 --height 8 --n_local_search_loops 2 \
+    --back_ratio 0.5 --use_metropolis_hastings
 
 Key features:
 - Implements local search sampling
 - Configurable number of local search loops
 - Adjustable backward step ratio
 - Optional Metropolis-Hastings acceptance criterion
-- Based on TB loss like the simple version
+- Based on TB loss like the train_hypergrid_simple.py example
 """
 
 import argparse
@@ -30,7 +29,7 @@ from gfn.preprocessors import KHotPreprocessor
 from gfn.samplers import LocalSearchSampler
 from gfn.states import DiscreteStates
 from gfn.utils.common import set_seed
-from gfn.utils.modules import MLP
+from gfn.utils.modules import MLP, DiscreteUniform
 from gfn.utils.training import validate
 
 
@@ -41,7 +40,13 @@ def main(args):
     )
 
     # Setup the Environment.
-    env = HyperGrid(ndim=args.ndim, height=args.height, device=device)
+    env = HyperGrid(
+        ndim=args.ndim,
+        height=args.height,
+        device=device,
+        calculate_partition=True,
+        store_all_states=True,
+    )
     preprocessor = KHotPreprocessor(height=env.height, ndim=env.ndim)
 
     # Build the GFlowNet.
@@ -49,18 +54,21 @@ def main(args):
         input_dim=preprocessor.output_dim,
         output_dim=env.n_actions,
     )
-    module_PB = MLP(
-        input_dim=preprocessor.output_dim,
-        output_dim=env.n_actions - 1,
-        trunk=module_PF.trunk,
-    )
+    if not args.uniform_pb:
+        module_PB = MLP(
+            input_dim=preprocessor.output_dim,
+            output_dim=env.n_actions - 1,
+            trunk=module_PF.trunk,
+        )
+    else:
+        module_PB = DiscreteUniform(output_dim=env.n_actions - 1)
     pf_estimator = DiscretePolicyEstimator(
         module_PF, env.n_actions, preprocessor=preprocessor, is_backward=False
     )
     pb_estimator = DiscretePolicyEstimator(
         module_PB, env.n_actions, preprocessor=preprocessor, is_backward=True
     )
-    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, logZ=0.0)
+    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, init_logZ=0.0)
 
     # Feed pf to the sampler.
     sampler = LocalSearchSampler(pf_estimator=pf_estimator, pb_estimator=pb_estimator)
@@ -126,6 +134,9 @@ if __name__ == "__main__":
         type=float,
         default=1e-1,
         help="Learning rate for the logZ parameter",
+    )
+    parser.add_argument(
+        "--uniform_pb", action="store_true", help="Use a uniform backward policy"
     )
     parser.add_argument(
         "--n_iterations", type=int, default=1000, help="Number of iterations"

--- a/tutorials/examples/train_hypergrid_simple.py
+++ b/tutorials/examples/train_hypergrid_simple.py
@@ -27,7 +27,7 @@ from gfn.preprocessors import KHotPreprocessor
 from gfn.samplers import Sampler
 from gfn.states import DiscreteStates
 from gfn.utils.common import set_seed
-from gfn.utils.modules import MLP
+from gfn.utils.modules import MLP, DiscreteUniform
 from gfn.utils.training import validate
 
 
@@ -38,7 +38,13 @@ def main(args):
     )
 
     # Setup the Environment.
-    env = HyperGrid(ndim=args.ndim, height=args.height, device=device)
+    env = HyperGrid(
+        ndim=args.ndim,
+        height=args.height,
+        device=device,
+        calculate_partition=True,
+        store_all_states=True,
+    )
     preprocessor = KHotPreprocessor(height=env.height, ndim=env.ndim)
 
     # Build the GFlowNet.
@@ -46,18 +52,21 @@ def main(args):
         input_dim=preprocessor.output_dim,
         output_dim=env.n_actions,
     )
-    module_PB = MLP(
-        input_dim=preprocessor.output_dim,
-        output_dim=env.n_actions - 1,
-        trunk=module_PF.trunk,
-    )
+    if not args.uniform_pb:
+        module_PB = MLP(
+            input_dim=preprocessor.output_dim,
+            output_dim=env.n_actions - 1,
+            trunk=module_PF.trunk,
+        )
+    else:
+        module_PB = DiscreteUniform(output_dim=env.n_actions - 1)
     pf_estimator = DiscretePolicyEstimator(
         module_PF, env.n_actions, preprocessor=preprocessor, is_backward=False
     )
     pb_estimator = DiscretePolicyEstimator(
         module_PB, env.n_actions, preprocessor=preprocessor, is_backward=True
     )
-    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, logZ=0.0)
+    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, init_logZ=0.0)
 
     # Feed pf to the sampler.
     sampler = Sampler(estimator=pf_estimator)
@@ -127,6 +136,9 @@ if __name__ == "__main__":
         type=float,
         default=1e-1,
         help="Learning rate for the logZ parameter",
+    )
+    parser.add_argument(
+        "--uniform_pb", action="store_true", help="Use a uniform backward policy"
     )
     parser.add_argument(
         "--n_iterations", type=int, default=1000, help="Number of iterations"

--- a/tutorials/examples/train_line.py
+++ b/tutorials/examples/train_line.py
@@ -313,7 +313,7 @@ def main(args):
         policy_std_max=policy_std_max,
     )
     pb = StepEstimator(environment, pb_module, backward=True)
-    gflownet = TBGFlowNet(pf=pf, pb=pb, logZ=0.0).to(device)
+    gflownet = TBGFlowNet(pf=pf, pb=pb, init_logZ=0.0).to(device)
 
     gflownet = train(
         gflownet,


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

Add GAFN (Generative Augmented Flow Networks, [Pan et al. 2021](https://arxiv.org/abs/2210.03308)) implementation.

This PR includes, specifically,
- GAFN implementation for HyperGrid env (see `tutorials/examples/train_hypergrid_gafn.py`)
- Make the reward function of HyperGrid configurable (see `gym/helpers/rewards.py`) and add a few reward functions. 
- Minor renaming `...dist_pmf` -> `...dist` (e.g., `true_dist_pmf` -> `true_dist`) since pmf is not general but only for discrete envs.