### PR TITLE
Remove edges of removed node

### DIFF
--- a/src/gfn/gym/graph_building.py
+++ b/src/gfn/gym/graph_building.py
@@ -213,7 +213,7 @@ class GraphBuilding(GraphEnv):
                     graph.edge_index[0] != node_idx, graph.edge_index[1] != node_idx
                 )
                 graph.edge_index[graph.edge_index > node_idx] -= 1
-                graph.edge_index = graph.edge_index[edge_mask]
+                graph.edge_index = graph.edge_index[:, edge_mask]
 
         # Handle ADD_EDGE action
         if torch.any(add_edge_mask):

--- a/src/gfn/gym/graph_building.py
+++ b/src/gfn/gym/graph_building.py
@@ -212,8 +212,8 @@ class GraphBuilding(GraphEnv):
                 edge_mask = torch.logical_and(
                     graph.edge_index[0] != node_idx, graph.edge_index[1] != node_idx
                 )
-                graph.edge_index[graph.edge_index > node_idx] -= 1
                 graph.edge_index = graph.edge_index[:, edge_mask]
+                graph.edge_index[graph.edge_index > node_idx] -= 1
 
         # Handle ADD_EDGE action
         if torch.any(add_edge_mask):

--- a/src/gfn/gym/graph_building.py
+++ b/src/gfn/gym/graph_building.py
@@ -209,10 +209,11 @@ class GraphBuilding(GraphEnv):
                 graph.x = graph.x[mask]
 
                 # Update edge indices
-                edge_mask = torch.logical_and(graph.edge_index[0] != node_idx, graph.edge_index[1] != node_idx)
+                edge_mask = torch.logical_and(
+                    graph.edge_index[0] != node_idx, graph.edge_index[1] != node_idx
+                )
                 graph.edge_index[graph.edge_index > node_idx] -= 1
                 graph.edge_index = graph.edge_index[edge_mask]
-
 
         # Handle ADD_EDGE action
         if torch.any(add_edge_mask):

--- a/src/gfn/gym/graph_building.py
+++ b/src/gfn/gym/graph_building.py
@@ -208,6 +208,12 @@ class GraphBuilding(GraphEnv):
                 # Update node features
                 graph.x = graph.x[mask]
 
+                # Update edge indices
+                edge_mask = torch.logical_and(graph.edge_index[0] != node_idx, graph.edge_index[1] != node_idx)
+                graph.edge_index[graph.edge_index > node_idx] -= 1
+                graph.edge_index = graph.edge_index[edge_mask]
+
+
         # Handle ADD_EDGE action
         if torch.any(add_edge_mask):
             add_edge_index = torch.where(add_edge_mask)[0]

--- a/src/gfn/utils/modules.py
+++ b/src/gfn/utils/modules.py
@@ -425,7 +425,7 @@ class GraphActionGNN(nn.Module):
         # Embed node classes
         if node_features.numel() > 0:
             x = self.embedding(node_features.squeeze(-1))
-        # Handle the case where the graph has no nodes. We use zeros as 
+        # Handle the case where the graph has no nodes. We use zeros as
         # features, so we can continue the forward pass.
         else:
             x = torch.zeros(0, self.hidden_dim, device=device)

--- a/testing/test_environments.py
+++ b/testing/test_environments.py
@@ -358,15 +358,15 @@ def test_graph_env():
         states = env._step(states, actions)
 
     # Add nodes.
-    for _ in range(NUM_NODES):
+    for i in range(NUM_NODES):
         actions = action_cls.from_tensor_dict(
             TensorDict(
                 {
                     GraphActions.ACTION_TYPE_KEY: torch.full(
                         (BATCH_SIZE,), GraphActionType.ADD_NODE
                     ),
-                    GraphActions.NODE_CLASS_KEY: torch.randint(
-                        0, 10, (BATCH_SIZE,), dtype=torch.long
+                    GraphActions.NODE_CLASS_KEY: torch.full(
+                        (BATCH_SIZE,), i, dtype=torch.long
                     ),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long


### PR DESCRIPTION
## Description
<!-- Describe your changes --> 

Current graph implementation doesn't handle the case where the policy wants to remove a node (in backward step) when there are edges associated to that node.

Two possible solutions:
 1) Do not allow removing nodes with associated edges via backward mask
 2) Remove the edges of a removed node
 
 I tried both approaches, but the first one makes the triangle tutorial more sample inefficient (~2x more training iterations to learn). On the other hand, the results are equivalent with the second approach, thus I implemented the latter here.


- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally
