### PR TITLE
Add node idx to GraphAction

### DIFF
--- a/src/gfn/actions.py
+++ b/src/gfn/actions.py
@@ -296,27 +296,29 @@ class GraphActions(Actions):
 
     ACTION_TYPE_KEY: ClassVar[str] = "action_type"
     NODE_CLASS_KEY: ClassVar[str] = "node_class"
+    NODE_INDEX_KEY: ClassVar[str] = "node_index"
     EDGE_CLASS_KEY: ClassVar[str] = "edge_class"
     EDGE_INDEX_KEY: ClassVar[str] = "edge_index"
 
     ACTION_INDICES: ClassVar[dict[str, int]] = {
         ACTION_TYPE_KEY: 0,
         NODE_CLASS_KEY: 1,
-        EDGE_CLASS_KEY: 2,
-        EDGE_INDEX_KEY: 3,
+        NODE_INDEX_KEY: 2,
+        EDGE_CLASS_KEY: 3,
+        EDGE_INDEX_KEY: 4,
     }
 
     def __init__(self, tensor: torch.Tensor):
         """Initializes a GraphActions object.
 
         Args:
-            tensor: A tensor of shape (*batch_shape, 4) containing the action type,
+            tensor: A tensor of shape (*batch_shape, 5) containing the action type,
                 node class, edge class, and edge index components.
         """
-        if tensor.shape[-1] != 4:
+        if tensor.shape[-1] != 5:
             raise ValueError(
-                f"Expected tensor of shape (*batch_shape, 4), got {tensor.shape}.\n"
-                "The last dimension should contain the action type, node class, edge class, and edge index."
+                f"Expected tensor of shape (*batch_shape, 5), got {tensor.shape}.\n"
+                "The last dimension should contain the action type, node class, node index, edge class, and edge index."
             )
         self.tensor = tensor
 
@@ -327,7 +329,7 @@ class GraphActions(Actions):
         Returns:
             The batch shape as a tuple.
         """
-        assert self.tensor.shape[-1] == 4
+        assert self.tensor.shape[-1] == 5
         return self.tensor.shape[:-1]
 
     @classmethod
@@ -336,7 +338,7 @@ class GraphActions(Actions):
 
         Args:
             tensor_dict: A TensorDict containing the action components with keys
-                ACTION_TYPE_KEY, NODE_CLASS_KEY, EDGE_CLASS_KEY, and EDGE_INDEX_KEY.
+                ACTION_TYPE_KEY, NODE_CLASS_KEY, NODE_INDEX_KEY, EDGE_CLASS_KEY, and EDGE_INDEX_KEY.
 
         Returns:
             A GraphActions object constructed from the tensor dict.
@@ -344,10 +346,11 @@ class GraphActions(Actions):
         batch_shape = tensor_dict[cls.ACTION_TYPE_KEY].shape
         action_type = tensor_dict[cls.ACTION_TYPE_KEY].reshape(*batch_shape, 1)
         node_class = tensor_dict[cls.NODE_CLASS_KEY].reshape(*batch_shape, 1)
+        node_index = tensor_dict[cls.NODE_INDEX_KEY].reshape(*batch_shape, 1)
         edge_class = tensor_dict[cls.EDGE_CLASS_KEY].reshape(*batch_shape, 1)
         edge_index = tensor_dict[cls.EDGE_INDEX_KEY].reshape(*batch_shape, 1)
 
-        return cls(torch.cat([action_type, node_class, edge_class, edge_index], dim=-1))
+        return cls(torch.cat([action_type, node_class, node_index, edge_class, edge_index], dim=-1))
 
     def __repr__(self):
         """Returns a string representation of the GraphActions object.
@@ -394,6 +397,15 @@ class GraphActions(Actions):
         return self.tensor[..., self.ACTION_INDICES[self.NODE_CLASS_KEY]]
 
     @property
+    def node_index(self) -> torch.Tensor:
+        """Returns the node index tensor.
+
+        Returns:
+            A tensor of shape (*batch_shape,) containing the node indices.
+        """
+        return self.tensor[..., self.ACTION_INDICES[self.NODE_INDEX_KEY]]
+
+    @property
     def edge_class(self) -> torch.Tensor:
         """Returns the edge class tensor.
 
@@ -425,7 +437,7 @@ class GraphActions(Actions):
             A GraphActions object with the specified batch shape filled with dummy
             actions.
         """
-        tensor = torch.zeros(batch_shape + (4,), dtype=torch.long, device=device)
+        tensor = torch.zeros(batch_shape + (5,), dtype=torch.long, device=device)
         tensor[..., cls.ACTION_INDICES[cls.ACTION_TYPE_KEY]] = GraphActionType.DUMMY
         return cls(tensor)
 
@@ -442,7 +454,7 @@ class GraphActions(Actions):
         Returns:
             A GraphActions object with the specified batch shape filled with exit actions.
         """
-        tensor = torch.zeros(batch_shape + (4,), dtype=torch.long, device=device)
+        tensor = torch.zeros(batch_shape + (5,), dtype=torch.long, device=device)
         tensor[..., cls.ACTION_INDICES[cls.ACTION_TYPE_KEY]] = GraphActionType.EXIT
         return cls(tensor)
 

--- a/src/gfn/actions.py
+++ b/src/gfn/actions.py
@@ -350,7 +350,11 @@ class GraphActions(Actions):
         edge_class = tensor_dict[cls.EDGE_CLASS_KEY].reshape(*batch_shape, 1)
         edge_index = tensor_dict[cls.EDGE_INDEX_KEY].reshape(*batch_shape, 1)
 
-        return cls(torch.cat([action_type, node_class, node_index, edge_class, edge_index], dim=-1))
+        return cls(
+            torch.cat(
+                [action_type, node_class, node_index, edge_class, edge_index], dim=-1
+            )
+        )
 
     def __repr__(self):
         """Returns a string representation of the GraphActions object.

--- a/src/gfn/estimators.py
+++ b/src/gfn/estimators.py
@@ -588,8 +588,12 @@ class DiscreteGraphPolicyEstimator(Estimator):
 
         # Check if no possible node can be added,
         # and assert that action type cannot be ADD_NODE
-        no_possible_node_class = torch.isneginf(logits[GraphActions.NODE_CLASS_KEY]).all(-1)
-        no_possible_node_index = torch.isneginf(logits[GraphActions.NODE_INDEX_KEY]).all(-1)
+        no_possible_node_class = torch.isneginf(logits[GraphActions.NODE_CLASS_KEY]).all(
+            -1
+        )
+        no_possible_node_index = torch.isneginf(logits[GraphActions.NODE_INDEX_KEY]).all(
+            -1
+        )
         assert torch.isneginf(
             logits[GraphActions.ACTION_TYPE_KEY][
                 no_possible_node_class & no_possible_node_index, GraphActionType.ADD_NODE
@@ -608,7 +612,9 @@ class DiscreteGraphPolicyEstimator(Estimator):
                 epsilon=epsilon[key],
             )
 
-        return GraphActionDistribution(probs=TensorDict(probs), is_backward=self.is_backward)
+        return GraphActionDistribution(
+            probs=TensorDict(probs), is_backward=self.is_backward
+        )
 
     @staticmethod
     def logits_to_probs(

--- a/src/gfn/estimators.py
+++ b/src/gfn/estimators.py
@@ -588,15 +588,15 @@ class DiscreteGraphPolicyEstimator(Estimator):
 
         # Check if no possible node can be added,
         # and assert that action type cannot be ADD_NODE
-        no_possible_node = torch.isneginf(logits[GraphActions.NODE_CLASS_KEY]).all(-1)
-        no_possible_node &= torch.isneginf(logits[GraphActions.NODE_INDEX_KEY]).all(-1)
+        no_possible_node_class = torch.isneginf(logits[GraphActions.NODE_CLASS_KEY]).all(-1)
+        no_possible_node_index = torch.isneginf(logits[GraphActions.NODE_INDEX_KEY]).all(-1)
         assert torch.isneginf(
             logits[GraphActions.ACTION_TYPE_KEY][
-                no_possible_node, GraphActionType.ADD_NODE
+                no_possible_node_class & no_possible_node_index, GraphActionType.ADD_NODE
             ]
         ).all()
-        logits[GraphActions.NODE_CLASS_KEY][no_possible_node] = 0.0
-        logits[GraphActions.NODE_INDEX_KEY][no_possible_node] = 0.0
+        logits[GraphActions.NODE_CLASS_KEY][no_possible_node_class] = 0.0
+        logits[GraphActions.NODE_INDEX_KEY][no_possible_node_index] = 0.0
 
         probs = {}
         for key in logits.keys():

--- a/src/gfn/gym/bayesian_structure.py
+++ b/src/gfn/gym/bayesian_structure.py
@@ -146,9 +146,15 @@ class BayesianStructure(GraphBuilding):
                 return TensorDict(
                     {
                         GraphActions.ACTION_TYPE_KEY: action_type,
-                        GraphActions.NODE_CLASS_KEY: torch.ones(
+                        GraphActions.NODE_CLASS_KEY: torch.zeros(
                             *self.batch_shape,
                             self.num_node_classes,
+                            dtype=torch.bool,
+                            device=self.device,
+                        ),
+                        GraphActions.NODE_INDEX_KEY: torch.zeros(
+                            *self.batch_shape,
+                            self.n_nodes,
                             dtype=torch.bool,
                             device=self.device,
                         ),
@@ -200,9 +206,15 @@ class BayesianStructure(GraphBuilding):
                 return TensorDict(
                     {
                         GraphActions.ACTION_TYPE_KEY: action_type,
-                        GraphActions.NODE_CLASS_KEY: torch.ones(
+                        GraphActions.NODE_CLASS_KEY: torch.zeros(
                             *self.batch_shape,
                             self.num_node_classes,
+                            dtype=torch.bool,
+                            device=self.device,
+                        ),
+                        GraphActions.NODE_INDEX_KEY: torch.zeros(
+                            *self.batch_shape,
+                            self.n_nodes,
                             dtype=torch.bool,
                             device=self.device,
                         ),

--- a/src/gfn/gym/bayesian_structure.py
+++ b/src/gfn/gym/bayesian_structure.py
@@ -60,7 +60,7 @@ class BayesianStructure(GraphBuilding):
         )
 
         super().__init__(
-            num_node_classes=1,
+            num_node_classes=n_nodes,
             num_edge_classes=1,
             state_evaluator=state_evaluator,
             is_directed=True,

--- a/src/gfn/gym/graph_building.py
+++ b/src/gfn/gym/graph_building.py
@@ -103,11 +103,10 @@ class GraphBuilding(GraphEnv):
             batch_indices_flat = torch.arange(len(states))[add_node_mask]
             add_node_action = actions[add_node_mask]
             node_class_action_flat = add_node_action.node_class.flatten()
-            node_index_action_flat = add_node_action.node_index.flatten()
 
             # Add nodes to the specified graphs
-            for graph_idx, new_node_class, new_node_index in zip(
-                batch_indices_flat, node_class_action_flat, node_index_action_flat
+            for graph_idx, new_node_class in zip(
+                batch_indices_flat, node_class_action_flat
             ):
                 # Get the graph to modify
                 graph = data_array[graph_idx]
@@ -121,8 +120,6 @@ class GraphBuilding(GraphEnv):
                         f"Node features must have dimension {graph.x.shape[1]}"
                     )
 
-                # Add new nodes to the graph
-                assert new_node_index == len(graph.x)
                 graph.x = torch.cat([graph.x, new_node_class], dim=0)
 
         # Handle ADD_EDGE action
@@ -243,13 +240,9 @@ class GraphBuilding(GraphEnv):
                 continue
 
             graph = data_array[i]
-            if action_type == GraphActionType.ADD_NODE:
-                if backward:
-                    if node_index_action_flat[i] >= len(graph.x):
-                        return False
-                else:
-                    if node_index_action_flat[i] != len(graph.x):
-                        return False
+            if action_type == GraphActionType.ADD_NODE and backward:
+                if node_index_action_flat[i] >= len(graph.x):
+                    return False
 
             elif action_type == GraphActionType.ADD_EDGE:
                 edge_idx = edge_index_action_flat[i]

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -888,12 +888,8 @@ class GraphStates(States):
         edge_masks = torch.ones(
             self.data.size, max_possible_edges, dtype=torch.bool, device=self.device
         )
-        node_index_masks = torch.zeros(
-            self.data.size, max_nodes + 1, dtype=torch.bool, device=self.device
-        )
 
         for i, graph in enumerate(self.data.flat):
-            node_index_masks[i, len(graph.x)] = True
             if graph.x is None:
                 continue
             ei0, ei1 = get_edge_indices(graph.x.size(0), self.is_directed, self.device)
@@ -911,7 +907,6 @@ class GraphStates(States):
 
                 edge_masks[i, : len(edge_idx)][edge_idx] = False
 
-        node_index_masks = node_index_masks.view(*self.batch_shape, max_nodes + 1)
         edge_masks = edge_masks.view(*self.batch_shape, max_possible_edges)
 
         # There are 3 action types: ADD_NODE, ADD_EDGE, EXIT
@@ -928,7 +923,12 @@ class GraphStates(States):
                     dtype=torch.bool,
                     device=self.device
                 ),
-                GraphActions.NODE_INDEX_KEY: node_index_masks,
+                GraphActions.NODE_INDEX_KEY: torch.zeros(
+                    *self.batch_shape,
+                    max_nodes,
+                    dtype=torch.bool,
+                    device=self.device,
+                ),
                 GraphActions.EDGE_CLASS_KEY: torch.ones(
                     *self.batch_shape,
                     self.num_edge_classes,
@@ -1005,7 +1005,7 @@ class GraphStates(States):
         return TensorDict(
             {
                 GraphActions.ACTION_TYPE_KEY: action_type,
-                GraphActions.NODE_CLASS_KEY: torch.ones(
+                GraphActions.NODE_CLASS_KEY: torch.zeros(
                     *self.batch_shape,
                     self.num_node_classes,
                     dtype=torch.bool,

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -921,7 +921,7 @@ class GraphStates(States):
                     *self.batch_shape,
                     self.num_node_classes,
                     dtype=torch.bool,
-                    device=self.device
+                    device=self.device,
                 ),
                 GraphActions.NODE_INDEX_KEY: torch.zeros(
                     *self.batch_shape,
@@ -975,7 +975,7 @@ class GraphStates(States):
         )
 
         for i, graph in enumerate(self.data.flat):
-            node_index_masks[i, :len(graph.x)] = True
+            node_index_masks[i, : len(graph.x)] = True
             if graph.x is None:
                 continue
             ei0, ei1 = get_edge_indices(graph.x.size(0), self.is_directed, self.device)
@@ -991,9 +991,7 @@ class GraphStates(States):
 
                 edge_masks[i, : len(edge_idx)][edge_idx] = True
 
-        node_index_masks = node_index_masks.view(
-            *self.batch_shape, max_nodes
-        )
+        node_index_masks = node_index_masks.view(*self.batch_shape, max_nodes)
         edge_masks = edge_masks.view(*self.batch_shape, max_possible_edges)
 
         # There are 3 action types: ADD_NODE, ADD_EDGE, EXIT

--- a/src/gfn/utils/distributions.py
+++ b/src/gfn/utils/distributions.py
@@ -87,10 +87,12 @@ class GraphActionDistribution(Distribution):
                 sample_shape
             )
             node_classes[add_node_idx] = node_classes_all[add_node_idx]
-            node_indices_all = self.dists[GraphActions.NODE_INDEX_KEY].sample(
-                sample_shape
-            )
-            node_indices[add_node_idx] = node_indices_all[add_node_idx]
+
+            if self.is_backward:
+                node_indices_all = self.dists[GraphActions.NODE_INDEX_KEY].sample(
+                    sample_shape
+                )
+                node_indices[add_node_idx] = node_indices_all[add_node_idx]
 
         add_edge_idx = action_types == GraphActionType.ADD_EDGE
         if add_edge_idx.any():
@@ -145,10 +147,11 @@ class GraphActionDistribution(Distribution):
                 sample[..., GraphActions.ACTION_INDICES[GraphActions.NODE_CLASS_KEY]]
             )
             log_prob[add_node_idx] += log_prob_node_class_all[add_node_idx]
-            log_prob_node_index_all = self.dists[GraphActions.NODE_INDEX_KEY].log_prob(
-                sample[..., GraphActions.ACTION_INDICES[GraphActions.NODE_INDEX_KEY]]
-            )
-            log_prob[add_node_idx] += log_prob_node_index_all[add_node_idx]
+            if self.is_backward:
+                log_prob_node_index_all = self.dists[GraphActions.NODE_INDEX_KEY].log_prob(
+                    sample[..., GraphActions.ACTION_INDICES[GraphActions.NODE_INDEX_KEY]]
+                )
+                log_prob[add_node_idx] += log_prob_node_index_all[add_node_idx]
 
         # If action_type is ADD_EDGE, add log_prob for EDGE_CLASS_KEY and EDGE_INDEX_KEY
         add_edge_idx = action_types == GraphActionType.ADD_EDGE

--- a/src/gfn/utils/distributions.py
+++ b/src/gfn/utils/distributions.py
@@ -148,7 +148,9 @@ class GraphActionDistribution(Distribution):
             )
             log_prob[add_node_idx] += log_prob_node_class_all[add_node_idx]
             if self.is_backward:
-                log_prob_node_index_all = self.dists[GraphActions.NODE_INDEX_KEY].log_prob(
+                log_prob_node_index_all = self.dists[
+                    GraphActions.NODE_INDEX_KEY
+                ].log_prob(
                     sample[..., GraphActions.ACTION_INDICES[GraphActions.NODE_INDEX_KEY]]
                 )
                 log_prob[add_node_idx] += log_prob_node_index_all[add_node_idx]

--- a/src/gfn/utils/distributions.py
+++ b/src/gfn/utils/distributions.py
@@ -51,13 +51,15 @@ class GraphActionDistribution(Distribution):
     - If the action_type is STOP, then no other components are sampled.
     """
 
-    def __init__(self, probs: TensorDict):
+    def __init__(self, probs: TensorDict, is_backward: bool):
         """Initializes the mixture distribution.
 
         Args:
             probs: A TensorDict of probs.
+            is_backward: A boolean indicating whether the distribution is for backward policy.
         """
         super().__init__()
+        self.is_backward = is_backward
 
         validate_args = False  # edge_index.numel() == 0 when no nodes are present
         self.dists = {
@@ -75,6 +77,7 @@ class GraphActionDistribution(Distribution):
         """
         action_types = self.dists[GraphActions.ACTION_TYPE_KEY].sample(sample_shape)
         node_classes = torch.zeros_like(action_types)
+        node_indices = torch.zeros_like(action_types)
         edge_classes = torch.zeros_like(action_types)
         edge_indices = torch.zeros_like(action_types)
 
@@ -84,6 +87,10 @@ class GraphActionDistribution(Distribution):
                 sample_shape
             )
             node_classes[add_node_idx] = node_classes_all[add_node_idx]
+            node_indices_all = self.dists[GraphActions.NODE_INDEX_KEY].sample(
+                sample_shape
+            )
+            node_indices[add_node_idx] = node_indices_all[add_node_idx]
 
         add_edge_idx = action_types == GraphActionType.ADD_EDGE
         if add_edge_idx.any():
@@ -99,6 +106,7 @@ class GraphActionDistribution(Distribution):
         components = {
             GraphActions.ACTION_TYPE_KEY: action_types,
             GraphActions.NODE_CLASS_KEY: node_classes,
+            GraphActions.NODE_INDEX_KEY: node_indices,
             GraphActions.EDGE_CLASS_KEY: edge_classes,
             GraphActions.EDGE_INDEX_KEY: edge_indices,
         }
@@ -130,13 +138,17 @@ class GraphActionDistribution(Distribution):
         ]
         log_prob += self.dists[GraphActions.ACTION_TYPE_KEY].log_prob(action_types)
 
-        # If action_type is ADD_NODE, add log_prob for NODE_CLASS_KEY
+        # If action_type is ADD_NODE, add log_prob for NODE_CLASS_KEY and NODE_INDEX_KEY
         add_node_idx = action_types == GraphActionType.ADD_NODE
         if add_node_idx.any():
             log_prob_node_class_all = self.dists[GraphActions.NODE_CLASS_KEY].log_prob(
                 sample[..., GraphActions.ACTION_INDICES[GraphActions.NODE_CLASS_KEY]]
             )
             log_prob[add_node_idx] += log_prob_node_class_all[add_node_idx]
+            log_prob_node_index_all = self.dists[GraphActions.NODE_INDEX_KEY].log_prob(
+                sample[..., GraphActions.ACTION_INDICES[GraphActions.NODE_INDEX_KEY]]
+            )
+            log_prob[add_node_idx] += log_prob_node_index_all[add_node_idx]
 
         # If action_type is ADD_EDGE, add log_prob for EDGE_CLASS_KEY and EDGE_INDEX_KEY
         add_edge_idx = action_types == GraphActionType.ADD_EDGE

--- a/src/gfn/utils/modules.py
+++ b/src/gfn/utils/modules.py
@@ -471,7 +471,9 @@ class GraphActionGNN(nn.Module):
         if self.is_backward:
             node_index_logits = self.node_index_mlp(x).squeeze(-1)
             node_index_logits = torch.split(node_index_logits, lengths.tolist(), dim=0)
-            node_index_logits = torch.nn.utils.rnn.pad_sequence(list(node_index_logits), batch_first=True)
+            node_index_logits = torch.nn.utils.rnn.pad_sequence(
+                list(node_index_logits), batch_first=True
+            )
         else:
             node_index_logits = torch.zeros(B, max_nodes, device=device)
 
@@ -699,14 +701,18 @@ class GraphEdgeActionMLP(nn.Module):
             node_features = self.features_embedding(states_tensor.x)
             node_index_logits = self.node_index_mlp(node_features).squeeze(-1)
             node_index_logits = torch.split(node_index_logits, lengths.tolist(), dim=0)
-            node_index_logits = torch.nn.utils.rnn.pad_sequence(list(node_index_logits), batch_first=True)
+            node_index_logits = torch.nn.utils.rnn.pad_sequence(
+                list(node_index_logits), batch_first=True
+            )
         else:
             exit_action = self.exit_mlp(embedding).squeeze(-1)
             action_type[..., GraphActionType.ADD_EDGE] = 0.0
             action_type[..., GraphActionType.EXIT] = exit_action
             edge_class_logits = self.edge_class_mlp(embedding)
             node_class_logits = self.node_class_mlp(embedding)
-            node_index_logits = torch.zeros(len(states_tensor), self.n_nodes, device=device)
+            node_index_logits = torch.zeros(
+                len(states_tensor), self.n_nodes, device=device
+            )
 
         return TensorDict(
             {

--- a/testing/test_actions.py
+++ b/testing/test_actions.py
@@ -19,7 +19,7 @@ def continuous_action():
 
 @pytest.fixture
 def graph_action():
-    return GraphActions(torch.zeros((1, 4)))
+    return GraphActions(torch.zeros((1, 5)))
 
 
 @pytest.mark.parametrize("action_fixture", ["continuous_action", "graph_action"])

--- a/testing/test_environments.py
+++ b/testing/test_environments.py
@@ -344,6 +344,9 @@ def test_graph_env():
                     GraphActions.NODE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
+                    GraphActions.NODE_INDEX_KEY: torch.zeros(
+                        (BATCH_SIZE,), dtype=torch.long
+                    ),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
@@ -357,7 +360,7 @@ def test_graph_env():
         states = env._step(states, actions)
 
     # Add nodes.
-    for _ in range(NUM_NODES):
+    for i in range(NUM_NODES):
         actions = action_cls.from_tensor_dict(
             TensorDict(
                 {
@@ -367,6 +370,7 @@ def test_graph_env():
                     GraphActions.NODE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
+                    GraphActions.NODE_INDEX_KEY: torch.tensor([i] * BATCH_SIZE),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
@@ -383,14 +387,16 @@ def test_graph_env():
 
     # We can't add a node with the same features.
     with pytest.raises(NonValidActionsError):
-        first_node_mask = torch.arange(len(states.tensor.x)) // BATCH_SIZE == 0
         actions = action_cls.from_tensor_dict(
             TensorDict(
                 {
                     GraphActions.ACTION_TYPE_KEY: torch.full(
                         (BATCH_SIZE,), GraphActionType.ADD_NODE
                     ),
-                    GraphActions.NODE_CLASS_KEY: states.tensor.x[first_node_mask],
+                    GraphActions.NODE_CLASS_KEY: torch.randint(
+                        0, 10, (BATCH_SIZE,), dtype=torch.long
+                    ),
+                    GraphActions.NODE_INDEX_KEY: torch.tensor([i] * BATCH_SIZE),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
@@ -414,6 +420,9 @@ def test_graph_env():
                     GraphActions.NODE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
+                    GraphActions.NODE_INDEX_KEY: torch.zeros(
+                        (BATCH_SIZE,), dtype=torch.long
+                    ),
                     GraphActions.EDGE_INDEX_KEY: torch.tensor([i] * BATCH_SIZE),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
@@ -431,6 +440,9 @@ def test_graph_env():
                     (BATCH_SIZE,), GraphActionType.EXIT
                 ),
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
+                    (BATCH_SIZE,), dtype=torch.long
+                ),
+                GraphActions.NODE_INDEX_KEY: torch.zeros(
                     (BATCH_SIZE,), dtype=torch.long
                 ),
                 GraphActions.EDGE_CLASS_KEY: torch.zeros(
@@ -460,6 +472,9 @@ def test_graph_env():
                     GraphActions.NODE_CLASS_KEY: torch.zeros(
                         (BATCH_SIZE,), dtype=torch.long
                     ),
+                    GraphActions.NODE_INDEX_KEY: torch.zeros(
+                        (BATCH_SIZE,), dtype=torch.long
+                    ),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
@@ -481,6 +496,9 @@ def test_graph_env():
                     GraphActions.NODE_CLASS_KEY: torch.zeros(
                         (BATCH_SIZE,), dtype=torch.long
                     ),
+                    GraphActions.NODE_INDEX_KEY: torch.zeros(
+                        (BATCH_SIZE,), dtype=torch.long
+                    ),
                     GraphActions.EDGE_CLASS_KEY: torch.randint(
                         0, 10, (BATCH_SIZE,), dtype=torch.long
                     ),
@@ -494,15 +512,17 @@ def test_graph_env():
         states = env._backward_step(states, actions)
 
     # Remove nodes.
-    for i in reversed(range(1, NUM_NODES + 1)):
-        edge_idx = torch.arange(BATCH_SIZE) * i
+    for i in reversed(range(NUM_NODES)):
         actions = action_cls.from_tensor_dict(
             TensorDict(
                 {
                     GraphActions.ACTION_TYPE_KEY: torch.full(
                         (BATCH_SIZE,), GraphActionType.ADD_NODE
                     ),
-                    GraphActions.NODE_CLASS_KEY: states.tensor.x[edge_idx],
+                    GraphActions.NODE_CLASS_KEY: torch.zeros(
+                        (BATCH_SIZE,), dtype=torch.long
+                    ),
+                    GraphActions.NODE_INDEX_KEY: torch.tensor([i] * BATCH_SIZE),
                     GraphActions.EDGE_CLASS_KEY: torch.zeros(
                         (BATCH_SIZE,), dtype=torch.long
                     ),
@@ -524,7 +544,10 @@ def test_graph_env():
                 GraphActions.ACTION_TYPE_KEY: torch.full(
                     (BATCH_SIZE,), GraphActionType.ADD_NODE
                 ),
-                GraphActions.NODE_CLASS_KEY: torch.zeros(
+                GraphActions.NODE_CLASS_KEY: torch.randint(
+                    0, 10, (BATCH_SIZE,), dtype=torch.long
+                ),
+                GraphActions.NODE_INDEX_KEY: torch.zeros(
                     (BATCH_SIZE,), dtype=torch.long
                 ),
                 GraphActions.EDGE_CLASS_KEY: torch.zeros(
@@ -547,7 +570,10 @@ def test_graph_env():
                     GraphActions.ACTION_TYPE_KEY: torch.full(
                         (BATCH_SIZE,), GraphActionType.ADD_NODE
                     ),
-                    GraphActions.NODE_CLASS_KEY: torch.ones(
+                    GraphActions.NODE_CLASS_KEY: torch.randint(
+                        0, 10, (BATCH_SIZE,), dtype=torch.long
+                    ),
+                    GraphActions.NODE_INDEX_KEY: torch.ones(
                         (BATCH_SIZE,), dtype=torch.long
                     ),
                     GraphActions.EDGE_CLASS_KEY: torch.zeros(
@@ -570,6 +596,9 @@ def test_graph_env():
                     (BATCH_SIZE,), GraphActionType.ADD_NODE
                 ),
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
+                    (BATCH_SIZE,), dtype=torch.long
+                ),
+                GraphActions.NODE_INDEX_KEY: torch.zeros(
                     (BATCH_SIZE,), dtype=torch.long
                 ),
                 GraphActions.EDGE_CLASS_KEY: torch.zeros(

--- a/testing/test_environments.py
+++ b/testing/test_environments.py
@@ -385,30 +385,6 @@ def test_graph_env():
 
     assert states.tensor.x.shape == (BATCH_SIZE * NUM_NODES, 1)
 
-    # We can't add a node with the same features.
-    with pytest.raises(NonValidActionsError):
-        actions = action_cls.from_tensor_dict(
-            TensorDict(
-                {
-                    GraphActions.ACTION_TYPE_KEY: torch.full(
-                        (BATCH_SIZE,), GraphActionType.ADD_NODE
-                    ),
-                    GraphActions.NODE_CLASS_KEY: torch.randint(
-                        0, 10, (BATCH_SIZE,), dtype=torch.long
-                    ),
-                    GraphActions.NODE_INDEX_KEY: torch.tensor([i] * BATCH_SIZE),
-                    GraphActions.EDGE_CLASS_KEY: torch.randint(
-                        0, 10, (BATCH_SIZE,), dtype=torch.long
-                    ),
-                    GraphActions.EDGE_INDEX_KEY: torch.randint(
-                        0, 10, (BATCH_SIZE,), dtype=torch.long
-                    ),
-                },
-                batch_size=BATCH_SIZE,
-            )
-        )
-        states = env._step(states, actions)
-
     # Add edges.
     for i in range(NUM_NODES**2 - NUM_NODES):
         actions = action_cls.from_tensor_dict(

--- a/testing/test_states.py
+++ b/testing/test_states.py
@@ -497,12 +497,14 @@ def test_forward_masks(datas):
         0, GraphActionType.EXIT
     ].item()  # Can exit
 
-    # Check features mask
+    # Check node class mask
     assert masks[GraphActions.NODE_CLASS_KEY].shape == (1, states.num_node_classes)
-    present_node_types = (
-        torch.bincount(states.tensor.x.flatten(), minlength=states.num_node_classes) > 0
-    )
-    assert torch.all(present_node_types == ~masks[GraphActions.NODE_CLASS_KEY])
+    assert torch.all(masks[GraphActions.NODE_CLASS_KEY])
+
+    # Check node index mask
+    assert masks[GraphActions.NODE_INDEX_KEY].shape == (1, states.tensor.x.size(0) + 1)
+    assert torch.all(~masks[GraphActions.NODE_INDEX_KEY][0, :states.tensor.x.size(0)])
+    assert masks[GraphActions.NODE_INDEX_KEY][0, states.tensor.x.size(0)]
 
     # Check edge_class mask
     assert masks[GraphActions.EDGE_CLASS_KEY].shape == (1, states.num_edge_classes)
@@ -537,10 +539,11 @@ def test_backward_masks(datas):
 
     # Check node_class mask
     assert masks[GraphActions.NODE_CLASS_KEY].shape == (1, states.num_node_classes)
-    available_nodes = (
-        torch.bincount(states.tensor.x.flatten(), minlength=states.num_node_classes) > 0
-    )
-    assert torch.all(available_nodes == masks[GraphActions.NODE_CLASS_KEY])
+    assert torch.all(masks[GraphActions.NODE_CLASS_KEY])
+
+    # Check node index mask
+    assert masks[GraphActions.NODE_INDEX_KEY].shape == (1, states.tensor.x.size(0))
+    assert torch.all(masks[GraphActions.NODE_INDEX_KEY])
 
     # Check edge_class mask
     assert masks[GraphActions.EDGE_CLASS_KEY].shape == (1, states.num_edge_classes)

--- a/testing/test_states.py
+++ b/testing/test_states.py
@@ -502,9 +502,8 @@ def test_forward_masks(datas):
     assert torch.all(masks[GraphActions.NODE_CLASS_KEY])
 
     # Check node index mask
-    assert masks[GraphActions.NODE_INDEX_KEY].shape == (1, states.tensor.x.size(0) + 1)
-    assert torch.all(~masks[GraphActions.NODE_INDEX_KEY][0, :states.tensor.x.size(0)])
-    assert masks[GraphActions.NODE_INDEX_KEY][0, states.tensor.x.size(0)]
+    assert masks[GraphActions.NODE_INDEX_KEY].shape == (1, states.tensor.x.size(0))
+    assert not torch.any(masks[GraphActions.NODE_INDEX_KEY])
 
     # Check edge_class mask
     assert masks[GraphActions.EDGE_CLASS_KEY].shape == (1, states.num_edge_classes)
@@ -539,7 +538,7 @@ def test_backward_masks(datas):
 
     # Check node_class mask
     assert masks[GraphActions.NODE_CLASS_KEY].shape == (1, states.num_node_classes)
-    assert torch.all(masks[GraphActions.NODE_CLASS_KEY])
+    assert not torch.any(masks[GraphActions.NODE_CLASS_KEY])
 
     # Check node index mask
     assert masks[GraphActions.NODE_INDEX_KEY].shape == (1, states.tensor.x.size(0))

--- a/tutorials/examples/train_bayesian_structure.py
+++ b/tutorials/examples/train_bayesian_structure.py
@@ -177,6 +177,9 @@ class DAGEdgeActionGNN(GraphActionGNN):
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
                     len(states_tensor), 1, device=x.device
                 ),
+                GraphActions.NODE_INDEX_KEY: torch.zeros(
+                    len(states_tensor), self.n_nodes, device=x.device
+                ),
                 GraphActions.EDGE_INDEX_KEY: edge_actions,
             },
             batch_size=len(states_tensor),
@@ -389,6 +392,9 @@ class DAGEdgeActionGNNv2(nn.Module):
                 ),  # TODO: make it learnable.
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
                     len(states_tensor), 1, device=node_embs.device
+                ),
+                GraphActions.NODE_INDEX_KEY: torch.zeros(
+                    len(states_tensor), self.n_nodes, device=node_embs.device
                 ),
                 GraphActions.EDGE_INDEX_KEY: edge_actions,
             },

--- a/tutorials/examples/train_bayesian_structure.py
+++ b/tutorials/examples/train_bayesian_structure.py
@@ -68,6 +68,7 @@ class DAGEdgeActionMLP(GraphEdgeActionMLP):
     def __init__(
         self,
         n_nodes: int,
+        num_node_classes: int,
         num_edge_classes: int,
         n_hidden_layers: int = 2,
         n_hidden_layers_exit: int = 1,
@@ -76,6 +77,7 @@ class DAGEdgeActionMLP(GraphEdgeActionMLP):
     ):
         super().__init__(
             n_nodes=n_nodes,
+            num_node_classes=num_node_classes,
             directed=True,
             num_edge_classes=num_edge_classes,
             n_hidden_layers=n_hidden_layers,
@@ -103,13 +105,15 @@ class DAGEdgeActionGNN(GraphActionGNN):
     def __init__(
         self,
         n_nodes: int,
+        num_node_classes: int,
         num_edge_classes: int,
         num_conv_layers: int = 1,
         embedding_dim: int = 128,
         is_backward: bool = False,
     ):
+        self.n_nodes = n_nodes
         super().__init__(
-            num_node_classes=n_nodes,
+            num_node_classes=num_node_classes,
             directed=True,
             num_edge_classes=num_edge_classes,
             num_conv_layers=num_conv_layers,
@@ -175,7 +179,7 @@ class DAGEdgeActionGNN(GraphActionGNN):
                     len(states_tensor), self.num_edge_classes, device=x.device
                 ),  # TODO: make it learnable.
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
-                    len(states_tensor), 1, device=x.device
+                    len(states_tensor), self.num_node_classes, device=x.device
                 ),
                 GraphActions.NODE_INDEX_KEY: torch.zeros(
                     len(states_tensor), self.n_nodes, device=x.device
@@ -203,6 +207,7 @@ class DAGEdgeActionGNNv2(nn.Module):
     def __init__(
         self,
         n_nodes: int,
+        num_node_classes: int,
         num_edge_classes: int,
         num_conv_layers: int = 2,
         embedding_dim: int = 128,
@@ -218,6 +223,7 @@ class DAGEdgeActionGNNv2(nn.Module):
         assert isinstance(is_backward, bool), "is_backward must be a boolean"
         self._input_dim = 1  # Each node input is a single integer before embedding.
         self._n_nodes = n_nodes
+        self.num_node_classes = num_node_classes
         self.embedding_dim = embedding_dim
         self.is_backward = is_backward
         self.num_edge_classes = num_edge_classes
@@ -226,7 +232,7 @@ class DAGEdgeActionGNNv2(nn.Module):
         if not self.is_backward:
             self._output_dim += 1  # +1 for exit action.
 
-        self.node_embedding = nn.Embedding(n_nodes, embedding_dim)
+        self.node_embedding = nn.Embedding(num_node_classes, embedding_dim)
         self.edge_embedding = nn.Parameter(
             torch.randn(1, embedding_dim).clamp(min=-2.0, max=2.0)
         )
@@ -391,7 +397,7 @@ class DAGEdgeActionGNNv2(nn.Module):
                     device=node_embs.device,
                 ),  # TODO: make it learnable.
                 GraphActions.NODE_CLASS_KEY: torch.zeros(
-                    len(states_tensor), 1, device=node_embs.device
+                    len(states_tensor), self.num_node_classes, device=node_embs.device
                 ),
                 GraphActions.NODE_INDEX_KEY: torch.zeros(
                     len(states_tensor), self.n_nodes, device=node_embs.device
@@ -430,6 +436,7 @@ def main(args: Namespace):
     if args.module == "mlp":
         pf_module = DAGEdgeActionMLP(
             n_nodes=env.n_nodes,
+            num_node_classes=env.num_node_classes,
             num_edge_classes=env.num_edge_classes,
             n_hidden_layers=args.num_layers,
             n_hidden_layers_exit=1,
@@ -438,6 +445,7 @@ def main(args: Namespace):
     elif args.module == "gnn":
         pf_module = DAGEdgeActionGNN(
             n_nodes=env.n_nodes,
+            num_node_classes=env.num_node_classes,
             num_edge_classes=env.num_edge_classes,
             num_conv_layers=args.num_layers,
             embedding_dim=args.embedding_dim,
@@ -445,6 +453,7 @@ def main(args: Namespace):
     elif args.module == "gnn_v2":
         pf_module = DAGEdgeActionGNNv2(
             n_nodes=env.n_nodes,
+            num_node_classes=env.num_node_classes,
             num_edge_classes=env.num_edge_classes,
             num_conv_layers=args.num_layers,
             embedding_dim=args.embedding_dim,

--- a/tutorials/examples/train_graph_ring.py
+++ b/tutorials/examples/train_graph_ring.py
@@ -291,6 +291,7 @@ def init_gflownet(
         module_pf = GraphEdgeActionMLP(
             num_nodes,
             directed,
+            num_node_classes=num_nodes,
             num_edge_classes=num_edge_classes,
             embedding_dim=embedding_dim,
         )
@@ -298,6 +299,7 @@ def init_gflownet(
             num_nodes,
             directed,
             is_backward=True,
+            num_node_classes=num_nodes,
             num_edge_classes=num_edge_classes,
             embedding_dim=embedding_dim,
         )

--- a/tutorials/examples/train_graph_triangle.py
+++ b/tutorials/examples/train_graph_triangle.py
@@ -17,7 +17,6 @@ from typing import Callable
 
 import torch
 
-from gfn.actions import GraphActions
 from gfn.containers import ReplayBuffer
 from gfn.estimators import DiscreteGraphPolicyEstimator
 from gfn.gflownet.trajectory_balance import TBGFlowNet
@@ -167,20 +166,12 @@ def main(args: argparse.Namespace) -> None:
         prioritized_sampling=True,
     )
 
-    epsilon = {
-        GraphActions.ACTION_TYPE_KEY: args.epsilon_action_type,
-        GraphActions.NODE_CLASS_KEY: args.epsilon_node_class,
-        GraphActions.EDGE_CLASS_KEY: args.epsilon_edge_class,
-        GraphActions.EDGE_INDEX_KEY: args.epsilon_edge_index,
-    }
-
     t0 = time.time()
     for it in range(args.n_iterations):
         trajectories = gflownet.sample_trajectories(
             env,
             n=args.batch_size,
             save_logprobs=True,
-            epsilon=epsilon,
         )
         training_samples = gflownet.to_training_samples(trajectories)
         gflownet_training_samples = training_samples
@@ -240,11 +231,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--use_buffer", action="store_true", default=True, help="Use replay buffer"
     )
-    # Exploration epsilons per action component
-    parser.add_argument("--epsilon_action_type", type=float, default=0.0)
-    parser.add_argument("--epsilon_node_class", type=float, default=0.0)
-    parser.add_argument("--epsilon_edge_class", type=float, default=0.0)
-    parser.add_argument("--epsilon_edge_index", type=float, default=0.0)
     parser.add_argument("--plot", action="store_true", default=False)
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description
<!-- Describe your changes --> 
Fixes https://github.com/GFNOrg/torchgfn/issues/383 and https://github.com/GFNOrg/torchgfn/issues/379.

This PR adds a new field to the GraphAction: NODE_IDX. This disentangle the NODE_CLASS to NODE_IDX, allowing to have graphs with multiple nodes from the same class. During forward steps, only the node class is considered. During backward step, only node index is considered and used to remove nodes. The node index is the index of `graph.x`.
