### PR TITLE
Multinode Replay Buffer Implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ torch = ">=2.6.0"
 tensordict = ">=0.6.1"
 torch_geometric = ">=2.6.1"
 linear-attention-transformer = ">=0.19.1"
+dill = ">=0.3.8"
 
 # dev dependencies.
 black = { version = "24.3", optional = true }

--- a/src/gfn/containers/message.py
+++ b/src/gfn/containers/message.py
@@ -1,0 +1,26 @@
+from enum import Enum, auto
+
+import dill as pickle
+import torch
+
+
+class MessageType(Enum):
+    DATA = auto()
+    EXIT = auto()
+
+
+class Message:
+    def __init__(self, type: MessageType, data=None):
+        self.type = type
+        self.data = data
+
+    def serialize(self):
+        """Convert message into a tensor of bytes."""
+        obj_bytes = pickle.dumps(self)
+        return torch.ByteTensor(list(obj_bytes))
+
+    @staticmethod
+    def deserialize(byte_tensor: torch.ByteTensor) -> "Message":
+        """Reconstruct message from a tensor of bytes."""
+        obj_bytes = bytes(byte_tensor.tolist())
+        return pickle.loads(obj_bytes)

--- a/src/gfn/containers/message.py
+++ b/src/gfn/containers/message.py
@@ -1,4 +1,5 @@
 from enum import Enum, auto
+from typing import Any
 
 import dill as pickle
 import torch
@@ -10,17 +11,17 @@ class MessageType(Enum):
 
 
 class Message:
-    def __init__(self, type: MessageType, data=None):
+    def __init__(self, type: MessageType, data: Any = None):
         self.type = type
         self.data = data
 
-    def serialize(self):
+    def serialize(self) -> torch.ByteTensor:
         """Convert message into a tensor of bytes."""
         obj_bytes = pickle.dumps(self)
         return torch.ByteTensor(list(obj_bytes))
 
     @staticmethod
-    def deserialize(byte_tensor: torch.ByteTensor) -> "Message":
-        """Reconstruct message from a tensor of bytes."""
+    def deserialize(byte_tensor: torch.ByteTensor) -> Message:
+        """Reconstruct Message from a tensor of bytes."""
         obj_bytes = bytes(byte_tensor.tolist())
         return pickle.loads(obj_bytes)

--- a/src/gfn/containers/message.py
+++ b/src/gfn/containers/message.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from enum import Enum, auto
 from typing import Any
 

--- a/src/gfn/containers/message.py
+++ b/src/gfn/containers/message.py
@@ -19,12 +19,12 @@ class Message:
     def serialize(self) -> torch.ByteTensor:
         """Convert message into a tensor of bytes."""
         obj_bytes = pickle.dumps(self)
-        
+
         return torch.ByteTensor(list(obj_bytes))
 
     @staticmethod
     def deserialize(byte_tensor: torch.ByteTensor) -> Message:
         """Reconstruct Message from a tensor of bytes."""
         obj_bytes = bytes(byte_tensor.tolist())
-        
+
         return pickle.loads(obj_bytes)

--- a/src/gfn/containers/message.py
+++ b/src/gfn/containers/message.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import Enum, auto
 from typing import Any
 
@@ -11,17 +12,19 @@ class MessageType(Enum):
 
 
 class Message:
-    def __init__(self, type: MessageType, data: Any = None):
-        self.type = type
-        self.data = data
+    def __init__(self, message_type: MessageType, message_data: Any = None):
+        self.message_type = type
+        self.message_data = data
 
     def serialize(self) -> torch.ByteTensor:
         """Convert message into a tensor of bytes."""
         obj_bytes = pickle.dumps(self)
+        
         return torch.ByteTensor(list(obj_bytes))
 
     @staticmethod
     def deserialize(byte_tensor: torch.ByteTensor) -> Message:
         """Reconstruct Message from a tensor of bytes."""
         obj_bytes = bytes(byte_tensor.tolist())
+        
         return pickle.loads(obj_bytes)

--- a/src/gfn/containers/message.py
+++ b/src/gfn/containers/message.py
@@ -13,8 +13,8 @@ class MessageType(Enum):
 
 class Message:
     def __init__(self, message_type: MessageType, message_data: Any = None):
-        self.message_type = type
-        self.message_data = data
+        self.message_type = message_type
+        self.message_data = message_data
 
     def serialize(self) -> torch.ByteTensor:
         """Convert message into a tensor of bytes."""

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -118,7 +118,7 @@ class ReplayBuffer:
         if self.remote_manager_rank is not None:
             self._add_counter += 1
             if self._add_counter % self.remote_buffer_freq == 0:
-                score = self._send_objs(len(training_container))
+                score = self._send_objs(training_container)
                 print(
                     f"[Rank {dist.get_rank()}] Sent to remote {self.remote_manager_rank}, got score {score}"
                 )

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -13,7 +13,6 @@ from gfn.containers.transitions import Transitions
 from gfn.env import Env
 
 
-
 @runtime_checkable
 class Container(Protocol):
     def __getitem__(self, idx): ...  # noqa: E704
@@ -106,7 +105,7 @@ class ReplayBuffer:
         first added container.
 
         Args:
-            training_container: The Trajectories, Transitions, or StatesContainer 
+            training_container: The Trajectories, Transitions, or StatesContainer
                 object to add.
         """
         if not isinstance(training_container, ValidContainerTypes):
@@ -142,7 +141,7 @@ class ReplayBuffer:
         # Receive a dummy score back
         score = torch.zeros(1, dtype=torch.float32)
         dist.recv(score, src=self.remote_manager_rank)
-        
+
         return score.item()
 
     def __repr__(self) -> str:

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -6,12 +6,12 @@ from typing import Protocol, Union, cast, runtime_checkable
 import torch
 import torch.distributed as dist
 
+from gfn.containers.message import Message, MessageType
 from gfn.containers.states_container import StatesContainer
 from gfn.containers.trajectories import Trajectories
 from gfn.containers.transitions import Transitions
 from gfn.env import Env
 
-from .message import Message, MessageType
 
 
 @runtime_checkable

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -111,9 +111,9 @@ class ReplayBuffer:
         if self.remote_manager_rank is not None:
             self._add_counter += 1
             if self._add_counter % self.remote_buffer_freq == 0:
-                reward = self._send_objs(len(training_objects))
+                score = self._send_objs(len(training_objects))
                 print(
-                    f"[Rank {dist.get_rank()}] Sent to remote {self.remote_manager_rank}, got reward {reward}"
+                    f"[Rank {dist.get_rank()}] Sent to remote {self.remote_manager_rank}, got score {score}"
                 )
 
     def _send_objs(self, training_objects):
@@ -132,10 +132,10 @@ class ReplayBuffer:
         # Now send the actual content
         dist.send(msg_tensor, dst=self.remote_manager_rank)
 
-        # Receive a dummy reward
-        reward = torch.zeros(1, dtype=torch.float32)
-        dist.recv(reward, src=self.remote_manager_rank)
-        return reward.item()
+        # Receive a dummy score back
+        score = torch.zeros(1, dtype=torch.float32)
+        dist.recv(score, src=self.remote_manager_rank)
+        return score.item()
 
     def __repr__(self):
         """Returns a string representation of the ReplayBuffer.

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -81,6 +81,13 @@ class ReplayBuffer:
         self.remote_manager_rank = remote_manager_rank
         self.remote_buffer_freq = remote_buffer_freq
         self._add_counter = 0
+        if self.remote_manager_rank is not None:
+            backend = dist.get_backend()
+            if backend != "gloo":
+                raise RuntimeError(
+                    f"Replay Buffer Manager is only supported with the 'gloo' backend, "
+                    f"but the current backend is '{backend}'."
+                )
 
     @property
     def device(self) -> torch.device:

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -1,0 +1,52 @@
+from typing import Callable, Optional
+
+import torch
+import torch.distributed as dist
+
+from .message import Message, MessageType
+
+
+class ReplayBufferManager:
+
+    def __init__(
+        self, rank: int, reward_function: Optional[Callable[[object], float]] = None
+    ):
+        self.rank = rank
+        self.is_running = True
+        self.reward_function = reward_function or self._default_reward
+
+    def _default_reward(self, obj) -> float:
+        """Default reward function if none provided"""
+        return float(len(str(obj)) * 0.1)
+
+    def run(self):
+        """Runs on remote buffer manager ranks. Waits for training data, computes dummy reward, sends back."""
+
+        while self.is_running:
+            # Receive data
+            sender_rank, msg, msg_data_len = self._recv_object()
+
+            if msg.type == MessageType.DATA:
+                reward = self.reward_function(msg.data)
+                reward_tensor = torch.tensor([reward], dtype=torch.float32)
+                dist.send(reward_tensor, dst=sender_rank)
+
+            else:
+                raise ValueError(
+                    f"Rank {self.rank} received unknown message type: {msg.type}"
+                )
+
+    def _recv_object(self):
+        # Receive the length
+        length_tensor = torch.IntTensor([0])
+        sender_rank = dist.recv(length_tensor)
+        length = length_tensor.item()
+
+        # Receive the actual serialized data
+        byte_tensor = torch.ByteTensor(length)
+        dist.recv(byte_tensor, src=sender_rank)
+
+        # Deserialize back into object
+        # obj_bytes = bytes(byte_tensor.tolist())
+        msg = Message.deserialize(byte_tensor)
+        return sender_rank, msg, length

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -37,12 +37,12 @@ class ReplayBufferManager:
             # Receive data
             sender_rank, msg, msg_data_len = self._recv_object()
 
-            if msg.type == MessageType.DATA:
-                reward = self.scoring_function(msg.data)
+            if msg.message_type == MessageType.DATA:
+                reward = self.scoring_function(msg.message_data)
                 reward_tensor = torch.tensor([reward], dtype=torch.float32)
                 dist.send(reward_tensor, dst=sender_rank)
 
-            elif msg.type == MessageType.EXIT:
+            elif msg.message_type == MessageType.EXIT:
                 self.exit_counter = self.exit_counter + 1
                 if self.exit_counter == self.num_training_ranks:
                     self.is_running = False
@@ -51,7 +51,7 @@ class ReplayBufferManager:
                     )
             else:
                 raise ValueError(
-                    f"Rank {self.rank} received unknown message type: {msg.type}"
+                    f"Rank {self.rank} received unknown message type: {msg.message_type}"
                 )
 
     def _recv_object(self):
@@ -73,7 +73,7 @@ class ReplayBufferManager:
     def send_termination_signal(manager_rank: int):
         """Sends a termination signal to the replay buffer manager."""
         rank = dist.get_rank()
-        msg = Message(type=MessageType.EXIT, data=None)
+        msg = Message(message_type=MessageType.EXIT, message_data=None)
         msg_bytes = msg.serialize()
         length_tensor = torch.IntTensor([len(msg_bytes)])
         dist.send(length_tensor, dst=manager_rank)

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -19,6 +19,12 @@ class ReplayBufferManager:
         self.exit_counter = 0
         self.num_training_ranks = num_training_ranks
         self.scoring_function = scoring_function or self.default_scoring_function
+        backend = dist.get_backend()
+        if backend != "gloo":
+            raise RuntimeError(
+                f"Replay Buffer Manager is only supported with the 'gloo' backend, "
+                f"but the current backend is '{backend}'."
+            )
 
     def default_scoring_function(self, obj) -> float:
         """Default reward function if none provided"""

--- a/testing/test_replay_buffer.py
+++ b/testing/test_replay_buffer.py
@@ -185,7 +185,8 @@ def test_save_load(simple_env, trajectories):
         assert isinstance(new_buffer.training_container.log_rewards, torch.Tensor)
         assert isinstance(buffer.training_container.log_rewards, torch.Tensor)
         assert torch.allclose(
-            new_buffer.training_container.log_rewards, buffer.training_container.log_rewards
+            new_buffer.training_container.log_rewards,
+            buffer.training_container.log_rewards,
         )
 
 

--- a/testing/test_replay_buffer.py
+++ b/testing/test_replay_buffer.py
@@ -81,7 +81,7 @@ def test_init_rb(simple_env):
     buffer = ReplayBuffer(simple_env, capacity=100)
     assert buffer.capacity == 100
     assert buffer.env == simple_env
-    assert buffer.training_objects is None
+    assert buffer.training_container is None
     assert len(buffer) == 0
     assert not buffer.prioritized_capacity
     assert not buffer.prioritized_sampling
@@ -95,8 +95,8 @@ def test_add_trajectories(simple_env, trajectories):
     buffer = ReplayBuffer(simple_env, capacity=10)
     buffer.add(trajectories)
 
-    assert buffer.training_objects is not None
-    assert isinstance(buffer.training_objects, Trajectories)
+    assert buffer.training_container is not None
+    assert isinstance(buffer.training_container, Trajectories)
     assert len(buffer) == 5
     assert "trajectories" in repr(buffer)
 
@@ -105,8 +105,8 @@ def test_add_transitions(simple_env, transitions):
     buffer = ReplayBuffer(simple_env, capacity=10)
     buffer.add(transitions)
 
-    assert buffer.training_objects is not None
-    assert isinstance(buffer.training_objects, Transitions)
+    assert buffer.training_container is not None
+    assert isinstance(buffer.training_container, Transitions)
     assert len(buffer) == 5
     assert "transitions" in repr(buffer)
 
@@ -115,8 +115,8 @@ def test_add_state_pairs(simple_env, state_pairs):
     buffer = ReplayBuffer(simple_env, capacity=10)
     buffer.add(state_pairs)
 
-    assert buffer.training_objects is not None
-    assert isinstance(buffer.training_objects, StatesContainer)
+    assert buffer.training_container is not None
+    assert isinstance(buffer.training_container, StatesContainer)
     assert len(buffer) == 10
     print(repr(buffer))
     assert "statescontainer" in repr(buffer)
@@ -128,10 +128,10 @@ def test_capacity_limit(simple_env, trajectories):
 
     assert len(buffer) == 3
     # Should keep the last 3 trajectories
-    assert isinstance(buffer.training_objects, Trajectories)
-    assert isinstance(buffer.training_objects.log_rewards, torch.Tensor)
-    assert buffer.training_objects.log_rewards is not None
-    assert buffer.training_objects.log_rewards[-3:].tolist() == [2.0, 3.0, 4.0]
+    assert isinstance(buffer.training_container, Trajectories)
+    assert isinstance(buffer.training_container.log_rewards, torch.Tensor)
+    assert buffer.training_container.log_rewards is not None
+    assert buffer.training_container.log_rewards[-3:].tolist() == [2.0, 3.0, 4.0]
 
 
 def test_prioritized_capacity(simple_env, trajectories):
@@ -142,10 +142,10 @@ def test_prioritized_capacity(simple_env, trajectories):
     assert not buffer.prioritized_sampling
     assert len(buffer) == 5
     # Should sort by log_rewards in ascending order
-    assert isinstance(buffer.training_objects, Trajectories)
-    assert isinstance(buffer.training_objects.log_rewards, torch.Tensor)
+    assert isinstance(buffer.training_container, Trajectories)
+    assert isinstance(buffer.training_container.log_rewards, torch.Tensor)
     assert torch.allclose(
-        buffer.training_objects.log_rewards, torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+        buffer.training_container.log_rewards, torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
     )
 
 
@@ -180,12 +180,12 @@ def test_save_load(simple_env, trajectories):
 
         # Check if loaded correctly
         assert len(new_buffer) == 5
-        assert isinstance(new_buffer.training_objects, Trajectories)
-        assert isinstance(buffer.training_objects, Trajectories)
-        assert isinstance(new_buffer.training_objects.log_rewards, torch.Tensor)
-        assert isinstance(buffer.training_objects.log_rewards, torch.Tensor)
+        assert isinstance(new_buffer.training_container, Trajectories)
+        assert isinstance(buffer.training_container, Trajectories)
+        assert isinstance(new_buffer.training_container.log_rewards, torch.Tensor)
+        assert isinstance(buffer.training_container.log_rewards, torch.Tensor)
         assert torch.allclose(
-            new_buffer.training_objects.log_rewards, buffer.training_objects.log_rewards
+            new_buffer.training_container.log_rewards, buffer.training_container.log_rewards
         )
 
 
@@ -240,10 +240,10 @@ def test_add_with_diversity(simple_env, trajectories):
 
     # The buffer should still prioritize by reward within the diverse set
     assert len(buffer) == 5
-    assert isinstance(buffer.training_objects, Trajectories)
-    assert isinstance(buffer.training_objects.log_rewards, torch.Tensor)
+    assert isinstance(buffer.training_container, Trajectories)
+    assert isinstance(buffer.training_container.log_rewards, torch.Tensor)
 
-    log_rewards = buffer.training_objects.log_rewards
+    log_rewards = buffer.training_container.log_rewards
     assert log_rewards is not None
     assert torch.all(log_rewards >= 0)
 
@@ -280,9 +280,9 @@ def test_skip_diversity_check(simple_env, trajectories):
 
     # The buffer should contain the highest reward trajectories
     assert len(buffer) == 5
-    assert isinstance(buffer.training_objects, Trajectories)
-    assert isinstance(buffer.training_objects.log_rewards, torch.Tensor)
-    assert torch.min(buffer.training_objects.log_rewards) >= 2.0
+    assert isinstance(buffer.training_container, Trajectories)
+    assert isinstance(buffer.training_container.log_rewards, torch.Tensor)
+    assert torch.min(buffer.training_container.log_rewards) >= 2.0
 
 
 def test_prioritized_sampling(simple_env, trajectories):


### PR DESCRIPTION
PR checklist:
-->

- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

This PR introduces multinode replay buffer support with the following features:

1. Ability to reserve one or more ranks as remote buffer managers using the `--num_remote_buffers` argument.
2. Remaining ranks act as training agents, which are automatically assigned to remote buffer managers.
3. Training agents specify their assigned remote buffer manager rank (if any) when creating a replay buffer.
4. The replay buffer communicates with its remote manager on `add` operation. This communication frequency is configurable via `ReplayBuffer.remote_buffer_freq`.
5. The remote buffer manager accepts a scoring function as an input parameter, used to evaluate and score replay buffer data.
6. The replay buffer managers automatically shutdown after all of its corresponding training agents have completed execution.
