### PR TITLE
Add TerminatingStateBuffer

### DIFF
--- a/src/gfn/containers/__init__.py
+++ b/src/gfn/containers/__init__.py
@@ -1,5 +1,9 @@
 from .base import Container
-from .replay_buffer import NormBasedDiversePrioritizedReplayBuffer, ReplayBuffer
+from .replay_buffer import (
+    NormBasedDiversePrioritizedReplayBuffer,
+    ReplayBuffer,
+    TerminatingStateBuffer,
+)
 from .states_container import StatesContainer
 from .trajectories import Trajectories
 from .transitions import Transitions
@@ -8,6 +12,7 @@ __all__ = [
     "NormBasedDiversePrioritizedReplayBuffer",
     "ReplayBuffer",
     "StatesContainer",
+    "TerminatingStateBuffer",
     "Trajectories",
     "Transitions",
     "Container",

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -388,7 +388,7 @@ class TerminatingStateBuffer(ReplayBuffer):
         conditioning = training_objects.conditioning
         log_rewards = training_objects.log_rewards
 
-        terminal_states_container = StatesContainer(
+        terminating_states_container = StatesContainer(
             env=self.env,
             states=terminating_states,
             conditioning=conditioning,
@@ -398,4 +398,4 @@ class TerminatingStateBuffer(ReplayBuffer):
             log_rewards=log_rewards,
         )
 
-        self._add_objs(terminal_states_container)
+        self._add_objs(terminating_states_container)

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -142,6 +142,12 @@ class ReplayBuffer:
         assert self.training_objects is not None
         assert isinstance(training_objects, type(self.training_objects))  # type: ignore
 
+        # Clear fields that must be recomputed for Trajectories and Transitions.
+        if isinstance(training_objects, (Trajectories, Transitions)):
+            training_objects.log_probs = None
+        if isinstance(training_objects, Trajectories):
+            training_objects.estimator_outputs = None
+
         # Adds the objects to the buffer.
         self.training_objects.extend(training_objects)  # type: ignore
 

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -27,7 +27,6 @@ class Container(Protocol):
 
 
 ContainerUnion = Union[Trajectories, Transitions, StatesContainer]
-ValidContainerTypes = (Trajectories, Transitions, StatesContainer)
 
 
 class ReplayBuffer:
@@ -88,7 +87,7 @@ class ReplayBuffer:
             training_objects: The Trajectories, Transitions, or StatesContainer object
                 to add.
         """
-        if not isinstance(training_objects, ValidContainerTypes):
+        if not isinstance(training_objects, ContainerUnion):
             raise TypeError("Must be a container type")
 
         self._add_objs(training_objects)
@@ -262,7 +261,7 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
             training_objects: The Trajectories, Transitions, or StatesContainer object
                 to add.
         """
-        if not isinstance(training_objects, ValidContainerTypes):
+        if not isinstance(training_objects, ContainerUnion):
             raise TypeError("Must be a container type")
 
         to_add = len(training_objects)
@@ -359,3 +358,38 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
             # If any training object remain after filtering, add them.
             if len(training_objects):
                 self._add_objs(training_objects)
+
+
+class TerminatingStateBuffer(ReplayBuffer):
+    """A replay buffer for storing terminating states.
+
+    Attributes:
+        env: The environment associated with the containers.
+        capacity: The maximum number of items the buffer can hold.
+        training_objects: The buffer contents (StatesContainer).
+    """
+
+    def __init__(self, env: Env, capacity: int = 1000, **kwargs):
+        super().__init__(env, capacity, **kwargs)
+        self.training_objects = StatesContainer(env)
+
+    def add(self, training_objects: ContainerUnion):
+        # Extract the terminating states from the training objects.
+        if not isinstance(training_objects, ContainerUnion):
+            raise TypeError("Must be a StatesContainer")
+
+        terminating_states = training_objects.terminating_states
+        conditioning = training_objects.conditioning
+        log_rewards = training_objects.log_rewards
+
+        terminal_states_container = StatesContainer(
+            env=self.env,
+            states=terminating_states,
+            conditioning=conditioning,
+            is_terminating=torch.ones(
+                len(terminating_states), dtype=torch.bool, device=self.env.device
+            ),
+            log_rewards=log_rewards,
+        )
+
+        self._add_objs(terminal_states_container)

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -142,14 +142,15 @@ class ReplayBuffer:
         assert self.training_objects is not None
         assert isinstance(training_objects, type(self.training_objects))  # type: ignore
 
-        # Clear fields that must be recomputed for Trajectories and Transitions.
-        if isinstance(training_objects, (Trajectories, Transitions)):
-            training_objects.log_probs = None
-        if isinstance(training_objects, Trajectories):
-            training_objects.estimator_outputs = None
-
         # Adds the objects to the buffer.
         self.training_objects.extend(training_objects)  # type: ignore
+
+        # Clear fields that must be recomputed for Trajectories and Transitions.
+        # Otherwise, we might accidentally use the old values.
+        if isinstance(self.training_objects, (Trajectories, Transitions)):
+            self.training_objects.log_probs = None
+        if isinstance(self.training_objects, Trajectories):
+            self.training_objects.estimator_outputs = None
 
         # Sort elements by log reward, capping the size at the defined capacity.
         if self.prioritized_capacity:

--- a/tutorials/examples/test_scripts.py
+++ b/tutorials/examples/test_scripts.py
@@ -93,6 +93,7 @@ class HypergridBufferArgs(HypergridArgs):
     prioritized_sampling: bool = False
 
 
+@dataclass
 class HypergridExplorationArgs(HypergridArgs):
     validation_interval: int = 5
     validation_samples: int = 100
@@ -720,5 +721,7 @@ def test_conditional_loss_types():
 
 def test_hypergrid_exploration_smoke():
     """Smoke test for the hypergrid exploration training script."""
-    args = asdict(HypergridExplorationArgs())  # type: ignore
-    train_hypergrid_exploration_main(**args)  # Runs without errors.
+    args = HypergridExplorationArgs()
+    args_dict = asdict(args)
+    namespace_args = Namespace(**args_dict)
+    train_hypergrid_exploration_main(namespace_args)  # Runs without errors.

--- a/tutorials/examples/test_scripts.py
+++ b/tutorials/examples/test_scripts.py
@@ -19,6 +19,7 @@ from .train_discreteebm import main as train_discreteebm_main
 from .train_graph_ring import main as train_graph_ring_main
 from .train_graph_triangle import main as train_graph_triangle_main
 from .train_hypergrid import main as train_hypergrid_main
+from .train_hypergrid_buffer import main as train_hypergrid_buffer_main
 from .train_hypergrid_gafn import main as train_hypergrid_gafn_main
 from .train_hypergrid_local_search import main as train_hypergrid_local_search_main
 from .train_hypergrid_simple import main as train_hypergrid_simple_main
@@ -78,6 +79,15 @@ class HypergridArgs(CommonArgs):
     R2: float = 2.0
     replay_buffer_size: int = 0
     timing: bool = True
+
+
+@dataclass
+class HypergridBufferArgs(HypergridArgs):
+    buffer_type: str = "terminating_state"
+    buffer_capacity: int = 100
+    prefill: int = 0
+    prioritized_capacity: bool = False
+    prioritized_sampling: bool = False
 
 
 @dataclass
@@ -459,6 +469,19 @@ def test_hypergrid_simple_smoke_fp64():
     args_dict = asdict(args)
     namespace_args = Namespace(**args_dict)
     train_hypergrid_simple_main(namespace_args)  # Just ensure it runs without errors.
+
+
+def test_hypergrid_buffer_smoke():
+    """Smoke test for the hypergrid buffer training script."""
+    args = HypergridBufferArgs(
+        batch_size=4,
+        hidden_dim=64,
+        n_hidden=1,
+        n_trajectories=10,  # Small number for smoke test
+    )
+    args_dict = asdict(args)
+    namespace_args = Namespace(**args_dict)
+    train_hypergrid_buffer_main(namespace_args)  # Just ensure it runs without errors.
 
 
 def test_hypergrid_gafn_smoke():

--- a/tutorials/examples/train_bayesian_structure.py
+++ b/tutorials/examples/train_bayesian_structure.py
@@ -376,7 +376,7 @@ class DAGEdgeActionGNNv2(nn.Module):
         receivers = self.receivers_mlp(attn_output)
         edge_actions = torch.bmm(senders, receivers.transpose(1, 2)).view(n_graphs, -1)
 
-        temperature = nn.functional.softplus(self.temperature)
+        temperature = F.softplus(self.temperature)
         edge_actions = edge_actions / temperature
 
         # Make TensorDict output

--- a/tutorials/examples/train_hypergrid_backward_sampling.py
+++ b/tutorials/examples/train_hypergrid_backward_sampling.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+r"""
+In this example, we will use backward sampling from the terminating states to train a GFlowNet.
+To do so, we will use the `TerminatingStateBuffer` to store the terminating states and sample from them.
+"""
+
+import argparse
+from typing import cast
+
+import torch
+from tqdm import tqdm
+
+from gfn.containers import TerminatingStateBuffer
+from gfn.estimators import DiscretePolicyEstimator
+from gfn.gflownet import TBGFlowNet
+from gfn.gym import HyperGrid
+from gfn.preprocessors import KHotPreprocessor
+from gfn.samplers import Sampler
+from gfn.states import DiscreteStates
+from gfn.utils.common import set_seed
+from gfn.utils.modules import MLP, DiscreteUniform
+from gfn.utils.training import validate
+
+
+def main(args):
+    set_seed(args.seed)
+    device = torch.device(
+        "cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu"
+    )
+
+    # Setup the Environment.
+    env = HyperGrid(
+        ndim=args.ndim,
+        height=args.height,
+        device=device,
+        calculate_partition=True,
+        store_all_states=True,
+    )
+    preprocessor = KHotPreprocessor(height=env.height, ndim=env.ndim)
+
+    # Build the GFlowNet.
+    module_PF = MLP(
+        input_dim=preprocessor.output_dim,
+        output_dim=env.n_actions,
+    )
+    if not args.uniform_pb:
+        module_PB = MLP(
+            input_dim=preprocessor.output_dim,
+            output_dim=env.n_actions - 1,
+            trunk=module_PF.trunk,
+        )
+    else:
+        module_PB = DiscreteUniform(output_dim=env.n_actions - 1)
+    pf_estimator = DiscretePolicyEstimator(
+        module_PF, env.n_actions, preprocessor=preprocessor, is_backward=False
+    )
+    pb_estimator = DiscretePolicyEstimator(
+        module_PB, env.n_actions, preprocessor=preprocessor, is_backward=True
+    )
+    gflownet = TBGFlowNet(pf=pf_estimator, pb=pb_estimator, init_logZ=0.0)
+    gflownet = gflownet.to(device)
+
+    # Feed pf to the sampler.
+    forward_sampler = Sampler(estimator=pf_estimator)
+    backward_sampler = Sampler(estimator=pb_estimator)
+
+    # Policy parameters have their own LR. Log Z gets dedicated learning rate
+    # (typically higher).
+    optimizer = torch.optim.Adam(gflownet.pf_pb_parameters(), lr=args.lr)
+    optimizer.add_param_group({"params": gflownet.logz_parameters(), "lr": args.lr_logz})
+
+    replay_buffer = TerminatingStateBuffer(env, capacity=args.buffer_capacity)
+
+    validation_info = {"l1_dist": float("inf")}
+    visited_terminating_states = env.states_from_batch_shape((0,))
+    for it in (pbar := tqdm(range(args.n_iterations), dynamic_ncols=True)):
+        trajectories = forward_sampler.sample_trajectories(
+            env,
+            n=args.batch_size,
+            save_logprobs=False,
+            save_estimator_outputs=False,
+            epsilon=args.epsilon,
+        )
+        visited_terminating_states.extend(
+            cast(DiscreteStates, trajectories.terminating_states)
+        )
+
+        with torch.no_grad():
+            replay_buffer.add(trajectories)  # This will add only the terminating states.
+
+        if it < args.prefill or len(replay_buffer) < args.batch_size:
+            continue
+
+        # First, train with on-policy trajectories
+        optimizer.zero_grad()
+        loss = gflownet.loss(env, trajectories, recalculate_all_logprobs=False)
+        loss.backward()
+        optimizer.step()
+
+        # Second, train with off-policy trajectories
+        # Terminating states are sampled from the replay buffer, and then
+        # backward trajectories are sampled starting from them using pb_estimator
+        terminating_states_container = replay_buffer.sample(n_samples=args.batch_size)
+        terminating_states = terminating_states_container.states
+        bwd_trajectories = backward_sampler.sample_trajectories(
+            env,
+            states=terminating_states,
+            save_logprobs=False,
+            save_estimator_outputs=False,
+            # TODO: log rewards, conditioning, ...
+        )
+        optimizer.zero_grad()
+        loss = gflownet.loss(
+            env,
+            bwd_trajectories.reverse_backward_trajectories(),
+            recalculate_all_logprobs=False,
+        )
+        loss.backward()
+        optimizer.step()
+
+        if (it + 1) % args.validation_interval == 0:
+            validation_info, _ = validate(
+                env,
+                gflownet,
+                args.validation_samples,
+                visited_terminating_states,
+            )
+            print(f"Iter {it + 1}: L1 distance {validation_info['l1_dist']:.8f}")
+        pbar.set_postfix({"loss": loss.item()})
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no_cuda", action="store_true", help="Prevent CUDA usage")
+    parser.add_argument(
+        "--ndim", type=int, default=4, help="Number of dimensions in the environment"
+    )
+    parser.add_argument(
+        "--height", type=int, default=16, help="Height of the environment"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=1e-3,
+        help="Learning rate for the estimators' modules",
+    )
+    parser.add_argument(
+        "--lr_logz",
+        type=float,
+        default=1e-1,
+        help="Learning rate for the logZ parameter",
+    )
+    parser.add_argument(
+        "--uniform_pb", action="store_true", help="Use a uniform backward policy"
+    )
+    parser.add_argument(
+        "--n_iterations", type=int, default=1000, help="Number of iterations"
+    )
+    parser.add_argument(
+        "--validation_interval", type=int, default=100, help="Validation interval"
+    )
+    parser.add_argument(
+        "--validation_samples",
+        type=int,
+        default=100000,
+        help="Number of validation samples to use to evaluate the probability mass function.",
+    )
+    parser.add_argument("--batch_size", type=int, default=16, help="Batch size")
+    parser.add_argument(
+        "--epsilon", type=float, default=0.1, help="Epsilon for the sampler"
+    )
+    parser.add_argument(
+        "--buffer_capacity",
+        type=int,
+        default=10000,
+        help="Capacity of the replay buffer",
+    )
+    parser.add_argument(
+        "--prefill",
+        type=int,
+        default=10,
+        help="Number of iterations to prefill the replay buffer",
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/tutorials/examples/train_hypergrid_buffer.py
+++ b/tutorials/examples/train_hypergrid_buffer.py
@@ -129,6 +129,7 @@ def main(args):
                 # TODO: log rewards, conditioning, ...
             )
             buffer_trajectories = bwd_trajectories.reverse_backward_trajectories()
+            buffer_trajectories._log_rewards = terminating_states_container.log_rewards
 
         optimizer.zero_grad()
         loss = gflownet.loss(env, buffer_trajectories, recalculate_all_logprobs=True)

--- a/tutorials/examples/train_hypergrid_buffer.py
+++ b/tutorials/examples/train_hypergrid_buffer.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
-r"""
-In this example, we will use backward sampling from the terminating states to train a GFlowNet.
-To do so, we will use the `TerminatingStateBuffer` to store the terminating states and sample from them.
+"""
+Example script for training a GFlowNet using replay buffers.
+
+This script demonstrates two approaches for off-policy training:
+1. Trajectory buffer: Stores and samples entire trajectories for training.
+2. Terminating state buffer: Stores terminating states, from which backward trajectories are sampled.
+
+Both buffer types can be selected to improve training efficiency and diversity.
 """
 
 import argparse

--- a/tutorials/examples/train_hypergrid_exploration_examples.py
+++ b/tutorials/examples/train_hypergrid_exploration_examples.py
@@ -313,33 +313,19 @@ def train(
     return results
 
 
-def main(
-    ndim: int = 2,
-    height: int = 8,
-    lr: float = 1e-3,
-    lr_logz: float = 1e-1,
-    batch_size: int = 16,
-    n_iterations: int = 1000,
-    uniform_pb: bool = False,
-    validation_interval: int = 100,
-    validation_samples: int = 100,
-    n_seeds: int = 3,
-    R1: float = 0.5,
-    R2: float = 2.0,
-    R0: float = 0.1,
-    no_cuda: bool = False,
-    plot: bool = True,
-):
+def main(args):
     # Setup the Environment.
-    device = torch.device("cuda" if torch.cuda.is_available() and not no_cuda else "cpu")
+    device = torch.device(
+        "cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu"
+    )
     env = HyperGrid(
-        ndim=ndim,
-        height=height,
+        ndim=args.ndim,
+        height=args.height,
         reward_fn_str="original",
         reward_fn_kwargs={
-            "R0": R0,
-            "R1": R1,
-            "R2": R2,
+            "R0": args.R0,
+            "R1": args.R1,
+            "R2": args.R2,
         },
         device=device,
         calculate_partition=True,
@@ -353,13 +339,13 @@ def main(
         "env": env,
         "preprocessor": preprocessor,
         "device": device,
-        "lr": lr,
-        "lr_logz": lr_logz,
-        "batch_size": batch_size,
-        "n_iterations": n_iterations,
-        "uniform_pb": uniform_pb,
-        "validation_interval": validation_interval,
-        "validation_samples": validation_samples,
+        "lr": args.lr,
+        "lr_logz": args.lr_logz,
+        "batch_size": args.batch_size,
+        "n_iterations": args.n_iterations,
+        "uniform_pb": args.uniform_pb,
+        "validation_interval": args.validation_interval,
+        "validation_samples": args.validation_samples,
     }
 
     # Intalize our four configurations.
@@ -443,7 +429,7 @@ def main(
         "logZ_diff",
     ]
     all_results = pd.DataFrame(columns=cols)  # type: ignore
-    for i, seed in enumerate(range(1234, 1234 + (42 * n_seeds), 42)):
+    for i, seed in enumerate(range(1234, 1234 + (42 * args.n_seeds), 42)):
         for experiment_name, experiment_kwargs in experiments.items():
             these_results = pd.DataFrame(columns=cols)  # type: ignore
             this_experiments_kwargs = {**experiment_kwargs, "seed": seed}
@@ -465,7 +451,7 @@ def main(
             all_results = pd.concat([all_results, these_results])
 
     # Adjust layout and save to home directory.
-    if plot:
+    if args.plot:
         # Create a figure with 3 subplots arranged horizontally
         fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(18, 6))
 
@@ -518,7 +504,7 @@ def main(
         # Print the result path
         print(f"\nPlot saved successfully to: {output_path}")
         print(
-            f"The figure shows comparison of exploration methods across {n_seeds} seeds."
+            f"The figure shows comparison of exploration methods across {args.n_seeds} seeds."
         )
 
     else:
@@ -598,4 +584,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    main(**args.__dict__)
+    main(args)

--- a/tutorials/examples/train_hypergrid_simple.py
+++ b/tutorials/examples/train_hypergrid_simple.py
@@ -131,7 +131,9 @@ def main(args):
             str_info = f"Iter {it + 1}: "
             if "l1_dist" in validation_info:
                 str_info += f"L1 distance={validation_info['l1_dist']:.8f} "
-            str_info += f"modes discovered={len(discovered_modes) / n_pixels_per_mode} "
+            str_info += (
+                f"modes discovered={len(discovered_modes) / n_pixels_per_mode:.3f} "
+            )
             str_info += f"n terminating states {len(visited_terminating_states)}"
             print(str_info)
 


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [x] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

Add `TerminatingStateBuffer`, which stores only the terminating states.

This could support potential use cases, such as:
1. When we have a dataset of terminating samples
2. When storing trajectories into the buffer requires too much memory
3. When we want to learn our sampler using multiple trajectories from a single terminating state

**Edit: Currently, learning with backward trajectory is sub-optimal in many aspects (e.g., backward sampling doesn't support `save_logprobs`, needs to call `reverse_backward_trajectories`, etc.). This point should be addressed in a subsequent PR.**