### PR TITLE
sf dtype correctly set

### DIFF
--- a/src/gfn/env.py
+++ b/src/gfn/env.py
@@ -6,7 +6,7 @@ from torch_geometric.data import Data as GeometricData
 
 from gfn.actions import Actions, GraphActions
 from gfn.states import DiscreteStates, GraphStates, States
-from gfn.utils.common import ensure_same_device, set_seed
+from gfn.utils.common import default_fill_value_for_dtype, ensure_same_device, set_seed
 
 # Errors
 NonValidActionsError = type("NonValidActionsError", (ValueError,), {})
@@ -62,7 +62,10 @@ class Env(ABC):
         self.s0 = s0
 
         if sf is None:
-            sf = torch.full(s0.shape, -float("inf"))
+            assert isinstance(s0, torch.Tensor), "When sf is None, s0 must be a Tensor"
+            sf = torch.full(
+                s0.shape, default_fill_value_for_dtype(s0.dtype), dtype=s0.dtype
+            )
         self.sf = sf.to(s0.device)  # pyright: ignore - torch_geometric type hint fix
 
         assert self.s0.shape == self.sf.shape == state_shape

--- a/src/gfn/utils/common.py
+++ b/src/gfn/utils/common.py
@@ -18,6 +18,34 @@ def is_int_dtype(tensor: torch.Tensor) -> bool:
     return not torch.is_floating_point(tensor) and not torch.is_complex(tensor)
 
 
+def default_fill_value_for_dtype(dtype: torch.dtype) -> int | float:
+    """Return default fill value for dtype.
+
+    - Float and complex dtypes → ``-inf``
+    - Integer dtypes → ``torch.iinfo(dtype).min``
+    - Bool dtype → ``0``
+    """
+
+    # Floats
+    if dtype in (torch.float16, torch.float32, torch.float64, torch.bfloat16):
+        return -float("inf")
+
+    # Complex
+    if dtype in (torch.complex64, torch.complex128):
+        return -float("inf")
+
+    # Bool
+    if dtype == torch.bool:
+        return 0
+
+    # Integers (incl. uint8)
+    try:
+        return torch.iinfo(dtype).min
+    except (TypeError, ValueError):
+        # Fallback for any unusual/unsupported dtype
+        return -float("inf")
+
+
 def get_available_cpus() -> int:
     """Return the number of *usable* CPUs for the current process.
 


### PR DESCRIPTION
<!-- 
IMPORTANT: Please review our contribution guidelines before submitting this PR:
https://github.com/GFNOrg/torchgfn/blob/main/.github/CONTRIBUTING.md

This repo has strict requirements for:
- Type annotations (checked with pyright)
- Test coverage
- VSCode configuration (pyright extension recommended)

PR checklist:
-->

- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [x] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description
sf now has dtype auto-set based on the submitted s0. also includes tests.