### PR TITLE
The action_shape should always be (1,) for DiscreteEnv

### DIFF
--- a/src/gfn/env.py
+++ b/src/gfn/env.py
@@ -445,9 +445,8 @@ class DiscreteEnv(Env, ABC):
         sf: Tensor of shape (*state_shape) representing the sink (final) state.
         n_actions: The number of actions in the environment.
         state_shape: Tuple representing the shape of the states.
-        action_shape: Tuple representing the shape of the actions.
-        dummy_action: Tensor of shape (*action_shape) representing the dummy action.
-        exit_action: Tensor of shape (*action_shape) representing the exit action.
+        dummy_action: Tensor of shape (1,) representing the dummy action.
+        exit_action: Tensor of shape (1,) representing the exit action.
         States: The States class associated with this environment.
         Actions: The Actions class associated with this environment.
         is_discrete: Class variable, whether the environment is discrete.
@@ -463,7 +462,6 @@ class DiscreteEnv(Env, ABC):
         s0: torch.Tensor,
         state_shape: Tuple | int,
         # Advanced parameters (optional):
-        action_shape: Tuple | int = (1,),
         dummy_action: Optional[torch.Tensor] = None,
         exit_action: Optional[torch.Tensor] = None,
         sf: Optional[torch.Tensor] = None,
@@ -475,10 +473,9 @@ class DiscreteEnv(Env, ABC):
             n_actions: The number of actions in the environment.
             s0: Tensor of shape (*state_shape) representing the initial state.
             state_shape: Tuple representing the shape of the states.
-            action_shape: Tuple representing the shape of the actions.
-            dummy_action: (Optional) Tensor of shape (*action_shape) representing the
+            dummy_action: (Optional) Tensor of shape (1,) representing the
                 dummy (padding) action.
-            exit_action: (Optional) Tensor of shape (*action_shape) representing the
+            exit_action: (Optional) Tensor of shape (1,) representing the
                 exit action.
             sf: (Optional) Tensor of shape (*state_shape) representing the final state.
             check_action_validity: Whether to check the action validity.
@@ -512,24 +509,20 @@ class DiscreteEnv(Env, ABC):
         if exit_action is None:
             exit_action = torch.tensor([n_actions - 1], device=s0.device)
 
-        # If these shapes are integers, convert them to tuples.
-        if isinstance(action_shape, int):
-            action_shape = (action_shape,)
-
         if isinstance(state_shape, int):
             state_shape = (state_shape,)
 
         assert dummy_action is not None
         assert exit_action is not None
         assert s0.shape == state_shape
-        assert dummy_action.shape == action_shape
-        assert exit_action.shape == action_shape
+        assert dummy_action.shape == (1,)
+        assert exit_action.shape == (1,)
 
         self.n_actions = n_actions  # Before init, for compatibility with States.
         super().__init__(
             s0,
             state_shape,
-            action_shape,
+            (1,),  # action shape is always (1,) for discrete environments
             dummy_action,
             exit_action,
             sf,

--- a/src/gfn/gym/bitSequence.py
+++ b/src/gfn/gym/bitSequence.py
@@ -238,7 +238,6 @@ class BitSequence(DiscreteEnv):
             self.words_per_seq, dtype=torch.long, device=torch.device(device_str)
         )
         state_shape = s0.shape
-        action_shape = (1,)
         dummy_action = -torch.ones(1, dtype=torch.long)
         exit_action = (self.n_actions - 1) * torch.ones(1, dtype=torch.long)
         sf = (self.n_actions - 1) * torch.ones(
@@ -248,7 +247,6 @@ class BitSequence(DiscreteEnv):
             self.n_actions,
             s0,
             state_shape,
-            action_shape,
             dummy_action,
             exit_action,
             sf,
@@ -750,7 +748,6 @@ class BitSequencePlus(BitSequence):
             self.words_per_seq, dtype=torch.long, device=torch.device(device_str)
         )
         state_shape = s0.shape
-        action_shape = (1,)
         dummy_action = -torch.ones(1, dtype=torch.long)
         exit_action = (n_actions - 1) * torch.ones(1, dtype=torch.long)
         sf = ((n_actions - 1) // 2) * torch.ones(
@@ -761,7 +758,6 @@ class BitSequencePlus(BitSequence):
             n_actions,
             s0,
             state_shape,
-            action_shape,
             dummy_action,
             exit_action,
             sf,

--- a/tutorials/examples/mRNA_design/env.py
+++ b/tutorials/examples/mRNA_design/env.py
@@ -78,7 +78,6 @@ class CodonDesignEnv(DiscreteEnv):
             n_actions=self.n_actions,
             s0=s0,
             state_shape=(self.seq_length,),
-            action_shape=(1,),  # Each action is a single index
             sf=sf,
         )
 


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [x] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description

The action_shape should always be (1,) for `DiscreteEnv`, since the action space is defined by the int `n_actions`, where `0` to `n_actions - 2` correspond to actions, and `n_actions - 1` corresponds to the [exit action](https://github.com/GFNOrg/torchgfn/blob/c3f309694b24aa4fd3cfae720e40c0a11eecb968/src/gfn/env.py#L513). This design also restricts the [shape of masks](https://github.com/GFNOrg/torchgfn/blob/c3f309694b24aa4fd3cfae720e40c0a11eecb968/src/gfn/states.py#L499) of `DiscreteStates`. 

This PR explicitly assigns (1,) to the action_shape of `DiscreteEnv`, preventing unexpected errors caused by arbitrary shapes.