### PR TITLE
Add backend-agnostic collective wrappers

### DIFF
--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -238,6 +238,7 @@ class ReplayBuffer:
 
     def _send_data(self, training_container: ContainerUnion) -> None:
         """Send a training container to the remote manager."""
+        assert self.remote_manager_rank is not None
         msg = Message(MessageType.DATA, training_container)
         with Timer(self.timing_data, "serialize_objs", enabled=self.timing):
             msg_tensor = msg.serialize()
@@ -395,7 +396,10 @@ class ReplayBuffer:
         """Returns a formatted string of the timing information for the replay buffer."""
         log_str = "Replay Buffer Timing Information:\n"
         for key, times in self.timing_data.items():
-            log_str += f"{key}: {sum(times):.4f} s\n"
+            total = sum(times)
+            count = len(times)
+            mean = total / count if count > 0 else 0.0
+            log_str += f"{key}: total={total:.4f}s, count={count}, mean={mean:.4f}s\n"
         return log_str
 
 
@@ -565,8 +569,21 @@ class TerminatingStateBuffer(ReplayBuffer):
         training_container: The buffer contents (StatesContainer).
     """
 
-    def __init__(self, env: Env, capacity: int = 1000, timing: bool = False, **kwargs):
-        super().__init__(env, capacity, timing=timing, **kwargs)
+    def __init__(
+        self,
+        env: Env,
+        capacity: int = 1000,
+        communication_backend: str = "mpi",
+        timing: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            env,
+            capacity,
+            communication_backend=communication_backend,
+            timing=timing,
+            **kwargs,
+        )
         self.training_container = StatesContainer(env)
 
     def _local_add(self, training_container: ContainerUnion):

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -109,14 +109,14 @@ class ReplayBufferManager:
         return sender_rank, msg, len(byte_tensor)
 
     @staticmethod
-    def send_termination_signal(manager_rank: int, backend):
+    def send_termination_signal(manager_rank: int, backend: str) -> None:
         """Sends a termination signal to the replay buffer manager."""
         msg = Message(message_type=MessageType.EXIT, message_data=None)
         msg_bytes = msg.serialize()
         send(msg_bytes, dst_rank=manager_rank, backend=backend)
 
     @staticmethod
-    def get_metadata(manager_rank: int, backend) -> dict:
+    def get_metadata(manager_rank: int, backend: str) -> dict:
         """Sends a get metadata signal to the replay buffer manager."""
         msg = Message(message_type=MessageType.GET_METADATA, message_data=None)
         msg_bytes = msg.serialize()

--- a/src/gfn/utils/distributed.py
+++ b/src/gfn/utils/distributed.py
@@ -692,10 +692,101 @@ def barrier(backend=default_backend, group=None):
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def get_rank(backend=default_backend):
+def get_rank(backend=default_backend, group=None):
     if backend == "torch":
-        return dist.get_rank()
+        return dist.get_rank(group)
     elif backend == "mpi":
-        return _get_MPI().COMM_WORLD.Get_rank()
+        MPI = _get_MPI()
+        comm = group if group is not None else MPI.COMM_WORLD
+        return comm.Get_rank()
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def get_world_size(backend=default_backend, group=None):
+    """Backend-agnostic world size query."""
+    if backend == "torch":
+        return dist.get_world_size(group)
+    elif backend == "mpi":
+        MPI = _get_MPI()
+        comm = group if group is not None else MPI.COMM_WORLD
+        return comm.Get_size()
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def all_reduce(tensor, op="SUM", backend=default_backend, group=None):
+    """Backend-agnostic all-reduce.
+
+    Args:
+        tensor: The tensor to reduce in-place.
+        op: Reduction operation. One of "SUM", "MAX", "MIN".
+        backend: Communication backend ("torch" or "mpi").
+        group: Process group (torch ProcessGroup or MPI communicator).
+    """
+    if backend == "torch":
+        torch_ops = {
+            "SUM": dist.ReduceOp.SUM,
+            "MAX": dist.ReduceOp.MAX,
+            "MIN": dist.ReduceOp.MIN,
+        }
+        dist.all_reduce(tensor, op=torch_ops[op], group=group)
+    elif backend == "mpi":
+        MPI = _get_MPI()
+        comm = group if group is not None else MPI.COMM_WORLD
+        mpi_ops = {"SUM": MPI.SUM, "MAX": MPI.MAX, "MIN": MPI.MIN}
+        arr = tensor.detach().cpu().numpy().copy()
+        comm.Allreduce(MPI.IN_PLACE, arr, op=mpi_ops[op])
+        tensor.copy_(torch.from_numpy(arr))
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def all_gather(output_list, tensor, backend=default_backend, group=None):
+    """Backend-agnostic all-gather.
+
+    Args:
+        output_list: List of pre-allocated tensors (one per rank) to receive
+            gathered data into.
+        tensor: The local tensor to send.
+        backend: Communication backend ("torch" or "mpi").
+        group: Process group (torch ProcessGroup or MPI communicator).
+    """
+    if backend == "torch":
+        dist.all_gather(output_list, tensor, group=group)
+    elif backend == "mpi":
+        import numpy as np
+
+        MPI = _get_MPI()
+        comm = group if group is not None else MPI.COMM_WORLD
+        send_arr = tensor.detach().cpu().numpy().copy()
+        recv_arr = np.empty(
+            [len(output_list)] + list(send_arr.shape), dtype=send_arr.dtype
+        )
+        comm.Allgather(send_arr, recv_arr)
+        for i, out in enumerate(output_list):
+            out.copy_(torch.from_numpy(recv_arr[i]))
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def broadcast(tensor, src, backend=default_backend, group=None):
+    """Backend-agnostic broadcast.
+
+    Args:
+        tensor: The tensor to broadcast. On the source rank this is the data
+            to send; on other ranks the buffer is overwritten with received data.
+        src: Source rank.
+        backend: Communication backend ("torch" or "mpi").
+        group: Process group (torch ProcessGroup or MPI communicator).
+    """
+    if backend == "torch":
+        dist.broadcast(tensor, src=src, group=group)
+    elif backend == "mpi":
+        MPI = _get_MPI()
+        comm = group if group is not None else MPI.COMM_WORLD
+        arr = tensor.detach().cpu().numpy().copy()
+        comm.Bcast(arr, root=src)
+        tensor.copy_(torch.from_numpy(arr))
     else:
         raise ValueError(f"Unknown backend: {backend}")

--- a/src/gfn/utils/distributed.py
+++ b/src/gfn/utils/distributed.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import torch
 import torch.distributed as dist
@@ -634,8 +634,39 @@ def gather_distributed_data(
 
 default_backend = "mpi"
 
+# Group type that works for both torch ProcessGroup and MPI communicator.
+Group = Any
 
-def send(data, dst_rank, backend=default_backend):
+
+def send(
+    data: torch.Tensor,
+    dst_rank: int,
+    backend: str = default_backend,
+) -> None:
+    """Send a byte tensor to ``dst_rank``.
+
+    This is **byte-level transport** — the payload is always sent as raw uint8
+    bytes. Both backends guarantee that ``recv`` on the other end will return
+    an identical uint8 tensor.
+
+    Protocol differences between backends:
+
+    - **torch**: Uses a length-prefixed two-message protocol. First a 1-element
+      int64 tensor containing the payload length is sent (tag=0), then the
+      payload itself (tag=1). This lets the receiver allocate the right buffer
+      size before the data arrives.
+    - **mpi**: Sends a single message (tag=0). The receiver uses ``MPI.Probe``
+      to discover the incoming message size before calling ``Recv``, so no
+      separate length message is needed.
+
+    Because the wire protocols differ, sender and receiver **must** use the
+    same backend.
+
+    Args:
+        data: Tensor to send (will be cast to uint8).
+        dst_rank: Destination rank (global).
+        backend: ``"torch"`` or ``"mpi"``.
+    """
     if backend == "torch":
         data = data.to(dtype=torch.uint8).contiguous().cpu()
         length_tensor = torch.tensor([data.numel()], dtype=torch.int64, device="cpu")
@@ -645,13 +676,29 @@ def send(data, dst_rank, backend=default_backend):
         MPI = _get_MPI()
         comm = MPI.COMM_WORLD
         arr = data.detach().cpu().contiguous().numpy()
-        comm.Send(arr, dest=dst_rank)
+        comm.Send(arr, dest=dst_rank, tag=0)
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def recv(src_rank=None, backend=default_backend):
+def recv(
+    src_rank: int | None = None,
+    backend: str = default_backend,
+) -> tuple[int, torch.Tensor]:
+    """Receive a byte tensor from ``src_rank`` (or any rank if ``None``).
+
+    Returns ``(source_rank, data)`` where ``data`` is a uint8 tensor. See
+    :func:`send` for protocol details per backend.
+
+    Args:
+        src_rank: Source rank to receive from, or ``None`` for any source.
+        backend: ``"torch"`` or ``"mpi"``.
+
+    Returns:
+        Tuple of (source rank, received uint8 tensor).
+    """
     if backend == "torch":
+        # Step 1: receive the payload length (tag=0).
         length_tensor = torch.zeros(1, dtype=torch.int64, device="cpu")
         if src_rank is None:
             src_rank = dist.recv(tensor=length_tensor, tag=0)
@@ -660,7 +707,7 @@ def recv(src_rank=None, backend=default_backend):
 
         msg_len = int(length_tensor.item())
 
-        # allocate payload buffer
+        # Step 2: receive the payload (tag=1).
         data = torch.empty(msg_len, dtype=torch.uint8, device="cpu")
         dist.recv(tensor=data, src=src_rank, tag=1)
         return src_rank, data
@@ -670,29 +717,42 @@ def recv(src_rank=None, backend=default_backend):
         comm = MPI.COMM_WORLD
         status = MPI.Status()
         source = MPI.ANY_SOURCE if src_rank is None else src_rank
+        # Probe to discover message size before allocating the receive buffer.
         comm.Probe(source=source, tag=0, status=status)
         source = status.Get_source()
         count = status.Get_count(MPI.BYTE)
-        buf = torch.ByteTensor(count)
+        buf = torch.empty(count, dtype=torch.uint8)
         comm.Recv(buf.numpy(), source=source, tag=0, status=status)
         return source, buf
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def barrier(backend=default_backend, group=None):
+def barrier(backend: str = default_backend, group: Group | None = None) -> None:
+    """Backend-agnostic barrier synchronization.
+
+    Args:
+        backend: ``"torch"`` or ``"mpi"``.
+        group: Process group (torch ProcessGroup or MPI communicator).
+    """
     if backend == "torch":
         group = dist.group.WORLD if group is None else group
         dist.barrier(group=group)
     elif backend == "mpi":
         MPI = _get_MPI()
-        group = MPI.COMM_WORLD if group is None else group
-        group.Barrier()
+        comm = MPI.COMM_WORLD if group is None else group
+        comm.Barrier()
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def get_rank(backend=default_backend, group=None):
+def get_rank(backend: str = default_backend, group: Group | None = None) -> int:
+    """Backend-agnostic rank query.
+
+    Args:
+        backend: ``"torch"`` or ``"mpi"``.
+        group: Process group (torch ProcessGroup or MPI communicator).
+    """
     if backend == "torch":
         return dist.get_rank(group)
     elif backend == "mpi":
@@ -703,8 +763,13 @@ def get_rank(backend=default_backend, group=None):
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def get_world_size(backend=default_backend, group=None):
-    """Backend-agnostic world size query."""
+def get_world_size(backend: str = default_backend, group: Group | None = None) -> int:
+    """Backend-agnostic world size query.
+
+    Args:
+        backend: ``"torch"`` or ``"mpi"``.
+        group: Process group (torch ProcessGroup or MPI communicator).
+    """
     if backend == "torch":
         return dist.get_world_size(group)
     elif backend == "mpi":
@@ -715,13 +780,21 @@ def get_world_size(backend=default_backend, group=None):
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def all_reduce(tensor, op="SUM", backend=default_backend, group=None):
-    """Backend-agnostic all-reduce.
+def all_reduce(
+    tensor: torch.Tensor,
+    op: str = "SUM",
+    backend: str = default_backend,
+    group: Group | None = None,
+) -> None:
+    """Backend-agnostic in-place all-reduce.
+
+    The MPI backend round-trips through CPU/numpy and copies the result back
+    to the original tensor (preserving its device).
 
     Args:
         tensor: The tensor to reduce in-place.
-        op: Reduction operation. One of "SUM", "MAX", "MIN".
-        backend: Communication backend ("torch" or "mpi").
+        op: Reduction operation. One of ``"SUM"``, ``"MAX"``, ``"MIN"``.
+        backend: ``"torch"`` or ``"mpi"``.
         group: Process group (torch ProcessGroup or MPI communicator).
     """
     if backend == "torch":
@@ -737,19 +810,27 @@ def all_reduce(tensor, op="SUM", backend=default_backend, group=None):
         mpi_ops = {"SUM": MPI.SUM, "MAX": MPI.MAX, "MIN": MPI.MIN}
         arr = tensor.detach().cpu().numpy().copy()
         comm.Allreduce(MPI.IN_PLACE, arr, op=mpi_ops[op])
-        tensor.copy_(torch.from_numpy(arr))
+        tensor.copy_(torch.from_numpy(arr).to(tensor.device))
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def all_gather(output_list, tensor, backend=default_backend, group=None):
+def all_gather(
+    output_list: list[torch.Tensor],
+    tensor: torch.Tensor,
+    backend: str = default_backend,
+    group: Group | None = None,
+) -> None:
     """Backend-agnostic all-gather.
+
+    The MPI backend round-trips through CPU/numpy and copies results back
+    to the output tensors (preserving their devices).
 
     Args:
         output_list: List of pre-allocated tensors (one per rank) to receive
             gathered data into.
         tensor: The local tensor to send.
-        backend: Communication backend ("torch" or "mpi").
+        backend: ``"torch"`` or ``"mpi"``.
         group: Process group (torch ProcessGroup or MPI communicator).
     """
     if backend == "torch":
@@ -765,19 +846,27 @@ def all_gather(output_list, tensor, backend=default_backend, group=None):
         )
         comm.Allgather(send_arr, recv_arr)
         for i, out in enumerate(output_list):
-            out.copy_(torch.from_numpy(recv_arr[i]))
+            out.copy_(torch.from_numpy(recv_arr[i]).to(out.device))
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
 
-def broadcast(tensor, src, backend=default_backend, group=None):
+def broadcast(
+    tensor: torch.Tensor,
+    src: int,
+    backend: str = default_backend,
+    group: Group | None = None,
+) -> None:
     """Backend-agnostic broadcast.
+
+    The MPI backend round-trips through CPU/numpy and copies the result back
+    to the tensor (preserving its device).
 
     Args:
         tensor: The tensor to broadcast. On the source rank this is the data
             to send; on other ranks the buffer is overwritten with received data.
         src: Source rank.
-        backend: Communication backend ("torch" or "mpi").
+        backend: ``"torch"`` or ``"mpi"``.
         group: Process group (torch ProcessGroup or MPI communicator).
     """
     if backend == "torch":
@@ -787,6 +876,6 @@ def broadcast(tensor, src, backend=default_backend, group=None):
         comm = group if group is not None else MPI.COMM_WORLD
         arr = tensor.detach().cpu().numpy().copy()
         comm.Bcast(arr, root=src)
-        tensor.copy_(torch.from_numpy(arr))
+        tensor.copy_(torch.from_numpy(arr).to(tensor.device))
     else:
         raise ValueError(f"Unknown backend: {backend}")

--- a/testing/test_distributed_wrappers.py
+++ b/testing/test_distributed_wrappers.py
@@ -1,0 +1,142 @@
+"""Tests for backend-agnostic collective wrappers in gfn.utils.distributed.
+
+These tests run in a single process without initializing any distributed
+backend, so they can only exercise:
+  - error paths (unknown backend)
+  - the torch backend via a minimal single-process process group
+  - basic API contracts (return types, shapes)
+
+Full multi-process / multi-rank tests require MPI or torch.distributed
+launchers and are not feasible in standard CI.
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from gfn.utils.distributed import (
+    all_gather,
+    all_reduce,
+    barrier,
+    broadcast,
+    get_rank,
+    get_world_size,
+    recv,
+    send,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def torch_pg():
+    """Initialize a single-process torch.distributed process group for testing.
+
+    Uses the gloo backend (CPU-only, no GPU required). Torn down after the
+    module's tests complete.
+    """
+    if dist.is_initialized():
+        yield None
+        return
+
+    dist.init_process_group(
+        backend="gloo",
+        init_method="tcp://127.0.0.1:29500",
+        rank=0,
+        world_size=1,
+    )
+    yield None
+    dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# Unknown backend error tests (no distributed init needed)
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownBackend:
+    """Every wrapper should raise ValueError for an unrecognized backend."""
+
+    def test_send_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            send(torch.zeros(1), dst_rank=0, backend="nccl_fake")
+
+    def test_recv_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            recv(src_rank=0, backend="nccl_fake")
+
+    def test_barrier_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            barrier(backend="nccl_fake")
+
+    def test_get_rank_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_rank(backend="nccl_fake")
+
+    def test_get_world_size_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_world_size(backend="nccl_fake")
+
+    def test_all_reduce_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            all_reduce(torch.zeros(1), backend="nccl_fake")
+
+    def test_all_gather_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            all_gather([torch.zeros(1)], torch.zeros(1), backend="nccl_fake")
+
+    def test_broadcast_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            broadcast(torch.zeros(1), src=0, backend="nccl_fake")
+
+
+# ---------------------------------------------------------------------------
+# Torch backend single-process tests
+# ---------------------------------------------------------------------------
+
+
+class TestTorchBackendSingleProcess:
+    """Tests using a single-process gloo process group (world_size=1)."""
+
+    def test_get_rank(self, torch_pg):
+        assert get_rank(backend="torch") == 0
+
+    def test_get_world_size(self, torch_pg):
+        assert get_world_size(backend="torch") == 1
+
+    def test_barrier(self, torch_pg):
+        # Should not raise.
+        barrier(backend="torch")
+
+    def test_all_reduce_sum(self, torch_pg):
+        t = torch.tensor([3.0, 4.0])
+        all_reduce(t, op="SUM", backend="torch")
+        # world_size=1, so all_reduce is identity.
+        assert torch.allclose(t, torch.tensor([3.0, 4.0]))
+
+    def test_all_reduce_max(self, torch_pg):
+        t = torch.tensor([1.0, 5.0, 3.0])
+        all_reduce(t, op="MAX", backend="torch")
+        assert torch.allclose(t, torch.tensor([1.0, 5.0, 3.0]))
+
+    def test_all_reduce_min(self, torch_pg):
+        t = torch.tensor([1.0, 5.0, 3.0])
+        all_reduce(t, op="MIN", backend="torch")
+        assert torch.allclose(t, torch.tensor([1.0, 5.0, 3.0]))
+
+    def test_all_gather(self, torch_pg):
+        t = torch.tensor([1.0, 2.0])
+        output = [torch.zeros(2)]
+        all_gather(output, t, backend="torch")
+        assert torch.allclose(output[0], t)
+
+    def test_broadcast(self, torch_pg):
+        t = torch.tensor([7.0, 8.0])
+        broadcast(t, src=0, backend="torch")
+        assert torch.allclose(t, torch.tensor([7.0, 8.0]))
+
+    # NOTE: send/recv cannot be tested in a single-process gloo group — gloo
+    # does not support self-sends and segfaults when attempted from threads.
+    # Full send/recv testing requires a multi-process launcher (e.g. mpirun).

--- a/testing/test_distributed_wrappers.py
+++ b/testing/test_distributed_wrappers.py
@@ -140,3 +140,61 @@ class TestTorchBackendSingleProcess:
     # NOTE: send/recv cannot be tested in a single-process gloo group — gloo
     # does not support self-sends and segfaults when attempted from threads.
     # Full send/recv testing requires a multi-process launcher (e.g. mpirun).
+
+
+# ---------------------------------------------------------------------------
+# MPI4py backend single-process tests
+# ---------------------------------------------------------------------------
+
+try:
+    import mpi4py  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+    _mpi4py_available = True
+except (ImportError, RuntimeError):
+    _mpi4py_available = False
+
+
+@pytest.mark.skipif(not _mpi4py_available, reason="mpi4py not available")
+class TestMPI4pyBackendSingleProcess:
+    """Tests using mpi4py with COMM_WORLD (world_size=1 without mpirun)."""
+
+    def test_get_rank(self):
+        assert get_rank(backend="mpi") == 0
+
+    def test_get_world_size(self):
+        assert get_world_size(backend="mpi") == 1
+
+    def test_barrier(self):
+        # Should not raise.
+        barrier(backend="mpi")
+
+    def test_all_reduce_sum(self):
+        t = torch.tensor([3.0, 4.0])
+        all_reduce(t, op="SUM", backend="mpi")
+        # world_size=1, so all_reduce is identity.
+        assert torch.allclose(t, torch.tensor([3.0, 4.0]))
+
+    def test_all_reduce_max(self):
+        t = torch.tensor([1.0, 5.0, 3.0])
+        all_reduce(t, op="MAX", backend="mpi")
+        assert torch.allclose(t, torch.tensor([1.0, 5.0, 3.0]))
+
+    def test_all_reduce_min(self):
+        t = torch.tensor([1.0, 5.0, 3.0])
+        all_reduce(t, op="MIN", backend="mpi")
+        assert torch.allclose(t, torch.tensor([1.0, 5.0, 3.0]))
+
+    def test_all_gather(self):
+        t = torch.tensor([1.0, 2.0])
+        output = [torch.zeros(2)]
+        all_gather(output, t, backend="mpi")
+        assert torch.allclose(output[0], t)
+
+    def test_broadcast(self):
+        t = torch.tensor([7.0, 8.0])
+        broadcast(t, src=0, backend="mpi")
+        assert torch.allclose(t, torch.tensor([7.0, 8.0]))
+
+    # NOTE: send/recv cannot be tested in a single-process MPI communicator —
+    # self-sends with blocking Send/Recv will deadlock or behave unexpectedly.
+    # Full send/recv testing requires a multi-process launcher (e.g. mpirun).

--- a/testing/test_distributed_wrappers.py
+++ b/testing/test_distributed_wrappers.py
@@ -147,7 +147,7 @@ class TestTorchBackendSingleProcess:
 # ---------------------------------------------------------------------------
 
 try:
-    import mpi4py  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    from mpi4py import MPI  # noqa: F401  # pyright: ignore[reportUnusedImport]
 
     _mpi4py_available = True
 except (ImportError, RuntimeError):


### PR DESCRIPTION
## Summary
- Adds `get_world_size`, `all_reduce`, `all_gather`, and `broadcast` backend-agnostic wrappers to `gfn.utils.distributed`, complementing the `send`/`recv`/`barrier`/`get_rank` wrappers from #489.
- Adds `group` parameter support to existing `get_rank` wrapper.
- All wrappers support both `"torch"` and `"mpi"` backends with the same API.

## Motivation
PR #489 added point-to-point wrappers, but downstream code (gfn-communities) also uses collective operations (`all_reduce` for gradient sync, `all_gather` for flag/metric exchange, `broadcast` for weight sync). These wrappers enable full migration from `torch.distributed` to mpi4py without maintaining parallel implementations.

## Test plan
- [x] Existing `test_utils.py` and `test_dependency_free.py` pass
- [x] All wrappers import correctly
- [ ] Integration testing with mpi4py on cluster (gfn-communities migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)