### PR TITLE
Use spawn (not fork) for HyperGrid multiprocessing.Pool

### DIFF
--- a/src/gfn/gym/hypergrid.py
+++ b/src/gfn/gym/hypergrid.py
@@ -3,7 +3,7 @@
 import itertools
 import logging
 import multiprocessing
-import platform
+import os
 import warnings
 from abc import ABC, abstractmethod
 from decimal import Decimal
@@ -21,15 +21,65 @@ from gfn.states import DiscreteStates
 
 logger = logging.getLogger(__name__)
 
-# Only set the multiprocessing start method when not already configured
-# (e.g. by Jupyter or another framework). force=True can crash notebook kernels.
+# Use ``spawn`` everywhere.  Historically this module set the start method to
+# ``fork`` on POSIX so that ``HyperGrid._worker`` (a bound method) could be
+# sent to a multiprocessing.Pool without pickling — fork inherits the parent
+# via memory copy, sidestepping the fact that ``HyperGridStates`` is a local
+# class and therefore unpicklable.
+#
+# Fork has three serious problems in modern usage:
+#   1. **MPI:** OpenMPI and Intel MPI both forbid ``fork()`` after MPI_Init.
+#      Fork inside an MPI rank duplicates libfabric/UCX provider state and
+#      causes silent corruption, hangs, or crashes.
+#   2. **CUDA:** CUDA contexts cannot be forked.  Any fork inside a process
+#      that has touched CUDA poisons the child.
+#   3. **Threads:** POSIX only allows async-signal-safe operations between
+#      ``fork()`` and ``exec()`` in a multi-threaded program.  Fork while
+#      another thread holds an allocator lock can deadlock the child.
+#
+# We now require all multiprocessing entry points in this module to be
+# picklable (``_hypergrid_worker`` is a module-level function, not a bound
+# method) and we use spawn unconditionally.
 try:
-    if platform.system() == "Windows":
-        multiprocessing.set_start_method("spawn")
-    else:
-        multiprocessing.set_start_method("fork")
+    multiprocessing.set_start_method("spawn")
 except RuntimeError:
-    pass  # Already set — don't override.
+    pass  # Already set — don't override (e.g. Jupyter, pytest-xdist).
+
+# Cap on the multiprocessing.Pool size used by ``_generate_combinations_in_batches``.
+# Without a cap, ``Pool()`` defaults to ``os.cpu_count()`` workers — on a 64-core
+# node hosting many co-located MPI ranks, that becomes ``ranks * 64`` worker
+# processes spawned simultaneously, which can wedge the kernel scheduler.
+_MAX_POOL_WORKERS = 8
+
+
+def _hypergrid_worker(task):
+    """Module-level worker for ``HyperGrid._generate_combinations_in_batches``.
+
+    Returns the requested slice of the Cartesian product as a concrete
+    ``list``.  Lives at module level (rather than as a bound method) so it
+    can be pickled to a spawned ``multiprocessing.Pool`` worker — bound
+    methods of ``HyperGrid`` are not picklable because the env's States
+    subclass is created locally inside ``make_states_class``.
+
+    Args:
+        task: ``(values, ndim, start_idx, end_idx)`` where ``values`` is the
+            list of coordinate values, ``ndim`` is the number of dimensions,
+            and ``[start_idx, end_idx)`` is the index range within the full
+            Cartesian product.
+
+    Returns:
+        A list of length ``end_idx - start_idx`` containing tuples of length
+        ``ndim``.  Returning a concrete list (rather than an
+        ``itertools.islice``) keeps the result picklable across workers and
+        future-proofs against the Python 3.14 removal of itertools pickle
+        support.
+    """
+    values, ndim, start_idx, end_idx = task
+    return list(
+        itertools.islice(
+            itertools.product(values, repeat=ndim), start_idx, end_idx
+        )
+    )
 
 
 def lcm(a, b):
@@ -926,19 +976,6 @@ class HyperGrid(DiscreteEnv):
         """Returns all terminating states of the environment."""
         return self.all_states
 
-    def _worker(self, task: tuple) -> itertools.islice:
-        """Return a slice of the Cartesian product for one batch.
-
-        Args:
-            task: (values, ndim, start_idx, end_idx) where values is the list
-                  of coordinate values, ndim is the number of dimensions, and
-                  [start_idx, end_idx) is the range within the full product.
-        """
-        values, ndim, start_idx, end_idx = task
-        return itertools.islice(
-            itertools.product(values, repeat=ndim), start_idx, end_idx
-        )
-
     def _generate_combinations_in_batches(
         self, ndim: int, max_val: int, batch_size: int
     ):
@@ -947,13 +984,22 @@ class HyperGrid(DiscreteEnv):
         Uses multiprocessing to avoid materializing the full product
         (size ``(max_val+1)^ndim``) in memory.
 
+        Workers are created via the spawn start method and execute the
+        module-level :func:`_hypergrid_worker` function so the call is safe
+        inside MPI ranks and CUDA contexts (see the start-method comment near
+        the top of this file).  Pool size is capped at ``MAX_POOL_WORKERS``
+        because larger pools just multiply per-rank fork/spawn overhead
+        without shrinking the per-task work — and a 64-core node hosting many
+        co-located MPI ranks can otherwise blow up to thousands of worker
+        processes simultaneously.
+
         Args:
             ndim: Number of dimensions (tuple length).
             max_val: Maximum coordinate value (inclusive).
             batch_size: Number of tuples per batch.
 
         Yields:
-            An iterator of tuples for each batch.
+            A list of tuples for each batch.
         """
         values = list(range(max_val + 1))
         total_combinations = (max_val + 1) ** ndim
@@ -962,8 +1008,9 @@ class HyperGrid(DiscreteEnv):
             for i in range(0, total_combinations, batch_size)
         ]
 
-        with multiprocessing.Pool() as pool:
-            for result in pool.imap(self._worker, tasks):
+        n_workers = min(_MAX_POOL_WORKERS, max(1, (os.cpu_count() or 1)))
+        with multiprocessing.Pool(processes=n_workers) as pool:
+            for result in pool.imap(_hypergrid_worker, tasks):
                 yield result
 
 

--- a/testing/test_gym_environments.py
+++ b/testing/test_gym_environments.py
@@ -48,9 +48,7 @@ class TestHyperGridInit:
 
     def test_enumerate_via_spawned_pool(self):
         """End-to-end: store_all_states triggers the Pool path under spawn."""
-        env = HyperGrid(
-            ndim=3, height=6, store_all_states=True, validate_modes=False
-        )
+        env = HyperGrid(ndim=3, height=6, store_all_states=True, validate_modes=False)
         assert env._all_states_tensor is not None
         # 6**3 = 216 unique states.
         assert env._all_states_tensor.shape == (216, 3)
@@ -97,7 +95,9 @@ class TestHyperGridInit:
         # If unset, importing hypergrid should set it to 'spawn'.
         # If already set (e.g. by another import), accept whatever's there
         # but flag if it's still 'fork' on POSIX.
-        import gfn.gym.hypergrid  # noqa: F401  (force the side-effect)
+        # This next line only exists to induce the side effect.
+        import gfn.gym.hypergrid  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
         method = multiprocessing.get_start_method()
         if method == "fork":
             pytest.skip(

--- a/testing/test_gym_environments.py
+++ b/testing/test_gym_environments.py
@@ -33,6 +33,80 @@ class TestHyperGridInit:
         env = HyperGrid(ndim=2, height=4, calculate_partition=True, validate_modes=False)
         assert env._log_partition is not None
 
+    # ------------------------------------------------------------------
+    # multiprocessing.Pool with the ``spawn`` start method
+    # ------------------------------------------------------------------
+    #
+    # ``HyperGrid._generate_combinations_in_batches`` previously used
+    # ``fork`` so it could send a bound method to the worker pool, which
+    # was incompatible with MPI/CUDA contexts.  We switched to ``spawn``
+    # plus a module-level ``_hypergrid_worker``.  These tests pin the new
+    # contract: enumerating all states must succeed under spawn, the worker
+    # must remain a picklable module-level callable, and the Pool size must
+    # be capped (so a 64-core node hosting many co-located ranks doesn't
+    # explode into ``ranks * num_cores`` simultaneous worker processes).
+
+    def test_enumerate_via_spawned_pool(self):
+        """End-to-end: store_all_states triggers the Pool path under spawn."""
+        env = HyperGrid(
+            ndim=3, height=6, store_all_states=True, validate_modes=False
+        )
+        assert env._all_states_tensor is not None
+        # 6**3 = 216 unique states.
+        assert env._all_states_tensor.shape == (216, 3)
+        # Every coordinate value 0..5 should be present in each dimension.
+        for d in range(3):
+            assert set(env._all_states_tensor[:, d].tolist()) == set(range(6))
+
+    def test_hypergrid_worker_is_picklable_module_level_function(self):
+        """The worker must be picklable so spawn can ship it to children."""
+        import pickle
+
+        from gfn.gym.hypergrid import _hypergrid_worker
+
+        # Module-level functions pickle by qualified name.
+        round_tripped = pickle.loads(pickle.dumps(_hypergrid_worker))
+        assert round_tripped is _hypergrid_worker
+
+        # And the worker actually does the right thing on a small task.
+        task = ([0, 1, 2], 2, 0, 4)
+        result = _hypergrid_worker(task)
+        assert isinstance(result, list)
+        assert result == [(0, 0), (0, 1), (0, 2), (1, 0)]
+        # Result must round-trip too (pool sends it back over a pipe).
+        assert pickle.loads(pickle.dumps(result)) == result
+
+    def test_pool_worker_count_is_capped(self):
+        """Sanity-check the cap so a future refactor can't accidentally
+        regress to ``Pool()`` with no ``processes=`` argument."""
+        from gfn.gym.hypergrid import _MAX_POOL_WORKERS
+
+        assert isinstance(_MAX_POOL_WORKERS, int)
+        assert 1 <= _MAX_POOL_WORKERS <= 32, (
+            f"Cap {_MAX_POOL_WORKERS} should be small to prevent fork/spawn "
+            f"storms when many MPI ranks are co-located on one node."
+        )
+
+    def test_start_method_is_spawn(self):
+        """``set_start_method('spawn')`` must take effect for safety inside
+        MPI/CUDA contexts.  Skipped if another framework already pinned the
+        start method to something else before pytest started."""
+        import multiprocessing
+
+        method = multiprocessing.get_start_method(allow_none=True)
+        # If unset, importing hypergrid should set it to 'spawn'.
+        # If already set (e.g. by another import), accept whatever's there
+        # but flag if it's still 'fork' on POSIX.
+        import gfn.gym.hypergrid  # noqa: F401  (force the side-effect)
+        method = multiprocessing.get_start_method()
+        if method == "fork":
+            pytest.skip(
+                "start method was pinned to 'fork' by another framework "
+                "before pytest started; the production code does call "
+                "set_start_method('spawn') but it was a no-op here."
+            )
+        assert method == "spawn", f"expected spawn, got {method}"
+
 
 class TestHyperGridRewardFunctions:
     """Test all reward function variants produce valid rewards."""


### PR DESCRIPTION
## Summary

The default `fork` start method on `HyperGrid._generate_combinations_in_batches`'s `multiprocessing.Pool` is unsafe in three contexts that matter for distributed training:

1. **MPI**: OpenMPI and Intel MPI both forbid `fork()` after `MPI_Init`. Forking inside an MPI rank duplicates libfabric/UCX provider state and leads to silent corruption, hangs, or crashes.
2. **CUDA**: CUDA contexts cannot be forked safely. Any fork inside a process that has touched CUDA poisons the child.
3. **Threads**: POSIX only allows async-signal-safe operations between `fork()` and `exec()` in a multi-threaded program. Forking while another thread holds the allocator lock can deadlock the child.

Fork was originally needed because `HyperGrid._worker` was a bound method, and `HyperGrid` itself is not picklable (its `States` subclass is created locally inside `make_states_class`). Fork sidestepped pickling by inheriting `self` via memory copy.

## Fix

- **Move `_worker` out of the class** to a module-level `_hypergrid_worker` function. It never used `self` anyway, so the change is purely structural.
- **Return a concrete `list`** instead of an `itertools.islice`. islice pickle support is being [removed in Python 3.14](https://docs.python.org/3/whatsnew/3.14.html), and lists are universally picklable across worker boundaries.
- **Cap `multiprocessing.Pool` to `_MAX_POOL_WORKERS = 8`**. The previous `Pool()` with no argument defaulted to `os.cpu_count()`, which on a 64-core node hosting many co-located MPI ranks could fan out into thousands of worker processes spawning simultaneously — a real foot-gun even outside the fork unsafety.
- **Set `multiprocessing.set_start_method("spawn")` unconditionally** on all platforms.
- Removes the now-unused `import platform`.

The trade-off: spawn re-execs `python` and re-imports the world per worker, so `_enumerate_all_states_tensor` startup goes from ~0.1s (fork) to ~4s (spawn) on a typical machine. For the only consumer of this path — `validate=True` / `store_all_states=True` at init — that's once-per-run overhead and the safety wins are worth it.

## Tests added

4 new tests in `TestHyperGridInit`:

- `test_enumerate_via_spawned_pool` — end-to-end exercise of `store_all_states=True` with the new spawn path; verifies all 6³=216 states are enumerated and every coordinate value appears in every dimension.
- `test_hypergrid_worker_is_picklable_module_level_function` — round-trips `_hypergrid_worker` through pickle, calls it on a small task, and asserts the **return value** is also picklable (the pool sends it back over a pipe).
- `test_pool_worker_count_is_capped` — regression guard against a future refactor accidentally restoring `Pool()` with no `processes=` argument.
- `test_start_method_is_spawn` — verifies the side-effect of importing `hypergrid` pins the start method to `"spawn"`. Skips gracefully if another framework already pinned it before pytest started.

## Test plan

- [x] All 71 tests in `testing/test_gym_environments.py` pass (including the previously-existing `test_store_all_states` and `test_calculate_partition` that exercise the same multiprocessing path).
- [x] Verified `HyperGrid(ndim=3, height=10, store_all_states=True)` enumerates all 1000 states correctly under spawn.
- [x] Verified `_hypergrid_worker` round-trips through `pickle.dumps`/`loads` and produces correct output.

## Why this is independent of #511

PR #511 (`fix/hypergrid-int64-overflow`) fixes the int64 overflow bug in `get_states_indices`. This PR fixes the multiprocessing safety bug. They touch the same file (`hypergrid.py`) but address different problems. Either can land first; if both land, the merge is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)