### PR TITLE
Use dedicated MPI tag for metadata queries

### DIFF
--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -137,6 +137,8 @@ class ReplayBufferManager:
         # listens on tag=0 for all incoming messages).  The *response* comes
         # back on METADATA_TAG so it cannot collide with async score replies.
         send(msg_bytes, dst_rank=manager_rank, backend=backend)
-        _src_rank, metadata_tensor = recv(manager_rank, backend=backend, tag=METADATA_TAG)
+        _src_rank, metadata_tensor = recv(
+            manager_rank, backend=backend, tag=METADATA_TAG
+        )
         metadata = Message.deserialize(metadata_tensor)
         return metadata.message_data

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -9,6 +9,13 @@ from gfn.containers.replay_buffer import (
 from gfn.env import Env
 from gfn.utils.distributed import recv, send
 
+# MPI tag constants for multiplexing independent message channels.
+# Data messages (trajectory submissions + score responses) use tag 0.
+# Metadata queries/responses use tag 1 so they never collide with
+# pending async score responses on the same rank pair.
+DATA_TAG = 0
+METADATA_TAG = 1
+
 
 class ReplayBufferManager:
 
@@ -87,6 +94,7 @@ class ReplayBufferManager:
                     metadata_tensor,
                     dst_rank=sender_rank,
                     backend=self.communication_backend,
+                    tag=METADATA_TAG,
                 )
 
             elif msg.message_type == MessageType.EXIT:
@@ -117,11 +125,18 @@ class ReplayBufferManager:
 
     @staticmethod
     def get_metadata(manager_rank: int, backend: str) -> dict:
-        """Sends a get metadata signal to the replay buffer manager."""
+        """Sends a get metadata signal to the replay buffer manager.
+
+        Uses ``METADATA_TAG`` so the response is never confused with
+        pending data/score messages on the default tag.
+        """
         msg = Message(message_type=MessageType.GET_METADATA, message_data=None)
         msg_bytes = msg.serialize()
 
+        # The request goes on the default DATA_TAG (the buffer's recv loop
+        # listens on tag=0 for all incoming messages).  The *response* comes
+        # back on METADATA_TAG so it cannot collide with async score replies.
         send(msg_bytes, dst_rank=manager_rank, backend=backend)
-        _src_rank, metadata_tensor = recv(manager_rank, backend=backend)
+        _src_rank, metadata_tensor = recv(manager_rank, backend=backend, tag=METADATA_TAG)
         metadata = Message.deserialize(metadata_tensor)
         return metadata.message_data

--- a/src/gfn/utils/distributed.py
+++ b/src/gfn/utils/distributed.py
@@ -642,6 +642,7 @@ def send(
     data: torch.Tensor,
     dst_rank: int,
     backend: str = default_backend,
+    tag: int = 0,
 ) -> None:
     """Send a byte tensor to ``dst_rank``.
 
@@ -652,12 +653,12 @@ def send(
     Protocol differences between backends:
 
     - **torch**: Uses a length-prefixed two-message protocol. First a 1-element
-      int64 tensor containing the payload length is sent (tag=0), then the
-      payload itself (tag=1). This lets the receiver allocate the right buffer
-      size before the data arrives.
-    - **mpi**: Sends a single message (tag=0). The receiver uses ``MPI.Probe``
-      to discover the incoming message size before calling ``Recv``, so no
-      separate length message is needed.
+      int64 tensor containing the payload length is sent (tag=2*tag), then the
+      payload itself (tag=2*tag+1). This lets the receiver allocate the right
+      buffer size before the data arrives.
+    - **mpi**: Sends a single message with the given ``tag``. The receiver uses
+      ``MPI.Probe`` to discover the incoming message size before calling
+      ``Recv``, so no separate length message is needed.
 
     Because the wire protocols differ, sender and receiver **must** use the
     same backend.
@@ -666,17 +667,19 @@ def send(
         data: Tensor to send (will be cast to uint8).
         dst_rank: Destination rank (global).
         backend: ``"torch"`` or ``"mpi"``.
+        tag: MPI/torch tag for message matching. Use distinct tags to
+            multiplex independent message channels on the same rank pair.
     """
     if backend == "torch":
         data = data.to(dtype=torch.uint8).contiguous().cpu()
         length_tensor = torch.tensor([data.numel()], dtype=torch.int64, device="cpu")
-        dist.send(tensor=length_tensor, dst=dst_rank, tag=0)
-        dist.send(tensor=data, dst=dst_rank, tag=1)
+        dist.send(tensor=length_tensor, dst=dst_rank, tag=2 * tag)
+        dist.send(tensor=data, dst=dst_rank, tag=2 * tag + 1)
     elif backend == "mpi":
         MPI = _get_MPI()
         comm = MPI.COMM_WORLD
         arr = data.detach().cpu().contiguous().numpy()
-        comm.Send(arr, dest=dst_rank, tag=0)
+        comm.Send(arr, dest=dst_rank, tag=tag)
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
@@ -684,6 +687,7 @@ def send(
 def recv(
     src_rank: int | None = None,
     backend: str = default_backend,
+    tag: int = 0,
 ) -> tuple[int, torch.Tensor]:
     """Receive a byte tensor from ``src_rank`` (or any rank if ``None``).
 
@@ -693,23 +697,25 @@ def recv(
     Args:
         src_rank: Source rank to receive from, or ``None`` for any source.
         backend: ``"torch"`` or ``"mpi"``.
+        tag: MPI/torch tag for message matching. Must match the tag used
+            by the corresponding :func:`send` call.
 
     Returns:
         Tuple of (source rank, received uint8 tensor).
     """
     if backend == "torch":
-        # Step 1: receive the payload length (tag=0).
+        # Step 1: receive the payload length (tag=2*tag).
         length_tensor = torch.zeros(1, dtype=torch.int64, device="cpu")
         if src_rank is None:
-            src_rank = dist.recv(tensor=length_tensor, tag=0)
+            src_rank = dist.recv(tensor=length_tensor, tag=2 * tag)
         else:
-            dist.recv(tensor=length_tensor, src=src_rank, tag=0)
+            dist.recv(tensor=length_tensor, src=src_rank, tag=2 * tag)
 
         msg_len = int(length_tensor.item())
 
-        # Step 2: receive the payload (tag=1).
+        # Step 2: receive the payload (tag=2*tag+1).
         data = torch.empty(msg_len, dtype=torch.uint8, device="cpu")
-        dist.recv(tensor=data, src=src_rank, tag=1)
+        dist.recv(tensor=data, src=src_rank, tag=2 * tag + 1)
         return src_rank, data
 
     elif backend == "mpi":
@@ -718,11 +724,11 @@ def recv(
         status = MPI.Status()
         source = MPI.ANY_SOURCE if src_rank is None else src_rank
         # Probe to discover message size before allocating the receive buffer.
-        comm.Probe(source=source, tag=0, status=status)
+        comm.Probe(source=source, tag=tag, status=status)
         source = status.Get_source()
         count = status.Get_count(MPI.BYTE)
         buf = torch.empty(count, dtype=torch.uint8)
-        comm.Recv(buf.numpy(), source=source, tag=0, status=status)
+        comm.Recv(buf.numpy(), source=source, tag=tag, status=status)
         return source, buf
     else:
         raise ValueError(f"Unknown backend: {backend}")


### PR DESCRIPTION
## Summary

- Adds `tag` parameter to `send()` and `recv()` in `distributed.py` (default 0, backward compatible)
- Defines `DATA_TAG=0` and `METADATA_TAG=1` constants in `replay_buffer_manager.py`
- Metadata responses now use `METADATA_TAG` so they never collide with pending async score responses on `DATA_TAG`

**Bug:** When `async_score=True` (the default), `get_metadata()` would receive a stale score dict instead of the metadata response, because both used MPI tag 0. This caused `n_modes_found` to be silently wrong or trigger an assertion failure.

**Fix:** The metadata response channel is now fully independent of the data channel via tag separation.

For the torch backend, tags are mapped to `2*tag` / `2*tag+1` (length prefix + payload) to stay compatible with the existing two-message protocol.

## Test plan

- [x] K=4 SA diagnostic: rank 0 reports `global=22523` vs `local=7758` — correctly deduplicated
- [x] Ranks 1-3 report only `n_modes_found_local` (no global key)
- [ ] Run existing torchgfn test suite to verify backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)