### PR TITLE
Support Open MPI env vars in distributed init

### DIFF
--- a/src/gfn/utils/distributed.py
+++ b/src/gfn/utils/distributed.py
@@ -362,12 +362,15 @@ def initialize_distributed_compute(
     ], f"Invalid backend requested: {dist_backend}"
 
     pmi_size = int(
-        _first_env(
-            "PMI_SIZE",
-            "OMPI_COMM_WORLD_SIZE",
-            "MV2_COMM_WORLD_SIZE",
-            "WORLD_SIZE",
-            default="0",
+        cast(
+            str,
+            _first_env(
+                "PMI_SIZE",
+                "OMPI_COMM_WORLD_SIZE",
+                "MV2_COMM_WORLD_SIZE",
+                "WORLD_SIZE",
+                default="0",
+            ),
         )
     )
     logger.info("Initializing distributed compute, detected world_size=%d", pmi_size)

--- a/src/gfn/utils/distributed.py
+++ b/src/gfn/utils/distributed.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _first_env(*names: str, default: str | None = None) -> str | None:
+    """Return the first non-empty environment variable from a list of names."""
+    for name in names:
+        value = os.environ.get(name)
+        if value not in (None, ""):
+            return value
+    return default
+
+
 def _get_MPI():
     """Lazily import and return the mpi4py MPI module."""
     from mpi4py import MPI
@@ -352,8 +361,16 @@ def initialize_distributed_compute(
         "gloo",
     ], f"Invalid backend requested: {dist_backend}"
 
-    pmi_size = int(os.environ.get("PMI_SIZE", "0"))  # 0 or 1 default value?
-    logger.info("Initializing distributed compute, PMI_SIZE=%d", pmi_size)
+    pmi_size = int(
+        _first_env(
+            "PMI_SIZE",
+            "OMPI_COMM_WORLD_SIZE",
+            "MV2_COMM_WORLD_SIZE",
+            "WORLD_SIZE",
+            default="0",
+        )
+    )
+    logger.info("Initializing distributed compute, detected world_size=%d", pmi_size)
 
     if pmi_size <= 1:
         logger.info("PMI_SIZE <= 1, running in single process mode.")
@@ -384,8 +401,26 @@ def initialize_distributed_compute(
     else:
         raise Exception(f"Invalid backend requested: {dist_backend}")
 
-    os.environ["RANK"] = os.environ.get("PMI_RANK", "0")
-    os.environ["WORLD_SIZE"] = os.environ.get("PMI_SIZE", "1")
+    os.environ["RANK"] = cast(
+        str,
+        _first_env(
+            "PMI_RANK",
+            "OMPI_COMM_WORLD_RANK",
+            "MV2_COMM_WORLD_RANK",
+            "RANK",
+            default="0",
+        ),
+    )
+    os.environ["WORLD_SIZE"] = cast(
+        str,
+        _first_env(
+            "PMI_SIZE",
+            "OMPI_COMM_WORLD_SIZE",
+            "MV2_COMM_WORLD_SIZE",
+            "WORLD_SIZE",
+            default="1",
+        ),
+    )
 
     logger.info("OMP_NUM_THREADS = %s", os.getenv("OMP_NUM_THREADS"))
 

--- a/testing/test_dependency_free.py
+++ b/testing/test_dependency_free.py
@@ -361,6 +361,68 @@ class TestDistributedReports:
             report_time_info(timing, world_size=2)
         assert "train" in caplog.text
 
+    def test_initialize_distributed_compute_uses_openmpi_env(self, monkeypatch):
+        try:
+            from gfn.utils import distributed as distributed_utils
+        except (ImportError, RuntimeError):
+            pytest.skip("mpi4py / MPI library not available")
+
+        for name in (
+            "PMI_SIZE",
+            "PMI_RANK",
+            "MV2_COMM_WORLD_SIZE",
+            "MV2_COMM_WORLD_RANK",
+            "WORLD_SIZE",
+            "RANK",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "4")
+        monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "2")
+
+        init_calls = {}
+        group_calls = []
+
+        monkeypatch.setattr(distributed_utils.dist, "is_gloo_available", lambda: True)
+        monkeypatch.setattr(
+            distributed_utils.dist,
+            "init_process_group",
+            lambda **kwargs: init_calls.update(kwargs),
+        )
+        monkeypatch.setattr(distributed_utils.dist, "barrier", lambda: None)
+        monkeypatch.setattr(distributed_utils.dist, "get_rank", lambda: 2)
+        monkeypatch.setattr(distributed_utils.dist, "get_world_size", lambda: 4)
+
+        def _fake_new_group(ranks, backend, timeout):
+            group_calls.append((tuple(ranks), backend))
+            return tuple(ranks)
+
+        monkeypatch.setattr(distributed_utils.dist, "new_group", _fake_new_group)
+        monkeypatch.setattr(
+            distributed_utils,
+            "initialize_distributed_compute_mpi4py",
+            lambda **kwargs: {"kwargs": kwargs},
+        )
+
+        ctx = distributed_utils.initialize_distributed_compute(
+            dist_backend="gloo",
+            num_remote_buffers=1,
+            num_agent_groups=1,
+        )
+
+        assert init_calls["world_size"] == 4
+        assert init_calls["rank"] == 2
+        assert init_calls["backend"] == "gloo"
+        assert group_calls == [
+            ((0, 1, 2), "gloo"),
+            ((0, 1, 2), "gloo"),
+            ((3,), "gloo"),
+        ]
+        assert ctx.my_rank == 2
+        assert ctx.world_size == 4
+        assert ctx.num_training_ranks == 3
+        assert ctx.assigned_buffer == 3
+        assert ctx.assigned_training_ranks is None
+
 
 # ===========================================================================
 # utils/graphs.py — edge index functions (pure torch)


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [x] I've added appropriate tests
- [ ] I've run pre-commit hooks locally

## Description
## Summary
- detect Open MPI and MVAPICH launcher environment variables when initializing distributed compute
- keep `RANK` / `WORLD_SIZE` in sync with the detected launcher-provided values before `dist.init_process_group`
- add a dependency-free unit test that exercises the Open MPI environment-variable path with mocked torch.distributed calls

## Why
`initialize_distributed_compute()` only looked at `PMI_*` variables before this change. On Trillium, the working launcher path is `mpirun` with Open MPI, which exports `OMPI_COMM_WORLD_*` instead. Without this patch, the code falls back to single-process mode even when multiple ranks are launched.

## Testing
- `python -m py_compile src/gfn/utils/distributed.py testing/test_dependency_free.py`
- `python -m pytest testing/test_dependency_free.py -k openmpi_env -v`
