### PR TITLE
Support callable and per-state policy temperatures

### DIFF
--- a/src/gfn/estimators.py
+++ b/src/gfn/estimators.py
@@ -206,6 +206,12 @@ class PolicyMixin:
                 with no_conditions_exception_handler("estimator", self):
                     estimator_outputs = self(states_active)  # type: ignore[misc]
 
+        if callable(policy_kwargs.get("temperature")):
+            policy_kwargs = dict(policy_kwargs)
+            policy_kwargs["temperature"] = policy_kwargs["temperature"](
+                states_active, estimator_outputs
+            )
+
         # Build the distribution.
         dist = self.to_probability_distribution(
             states_active, estimator_outputs, **policy_kwargs
@@ -306,6 +312,12 @@ class RecurrentPolicyMixin(PolicyMixin):
         """
         estimator_outputs, new_carry = self(states_active, ctx.carry)  # type: ignore
         ctx.carry = new_carry
+        if callable(policy_kwargs.get("temperature")):
+            policy_kwargs = dict(policy_kwargs)
+            policy_kwargs["temperature"] = policy_kwargs["temperature"](
+                states_active, estimator_outputs
+            )
+
         dist = self.to_probability_distribution(
             states_active,
             estimator_outputs,
@@ -551,11 +563,14 @@ class LogitBasedEstimator(Estimator):
         masks: torch.Tensor,
         sf_index: int | None,
         sf_bias: float,
-        temperature: float,
+        temperature: float | torch.Tensor,
         debug: bool = False,
     ) -> torch.Tensor:
         """Clone and apply mask, bias and temperature to logits."""
-        assert temperature > 0.0
+        if isinstance(temperature, torch.Tensor):
+            assert torch.all(temperature > 0.0)
+        else:
+            assert temperature > 0.0
 
         x = logits.clone()
         x[~masks] = -float("inf")
@@ -584,7 +599,12 @@ class LogitBasedEstimator(Estimator):
         if sf_index is not None and sf_bias != 0.0:
             x[..., sf_index] = x[..., sf_index] - sf_bias
 
-        if temperature != 1.0:
+        if isinstance(temperature, torch.Tensor):
+            temp = temperature.to(device=x.device, dtype=x.dtype)
+            while temp.ndim < x.ndim:
+                temp = temp.unsqueeze(-1)
+            x = x / temp
+        elif temperature != 1.0:
             x = x / temperature
 
         return x
@@ -652,7 +672,7 @@ class LogitBasedEstimator(Estimator):
         masks: torch.Tensor,
         sf_index: int | None,
         sf_bias: float,
-        temperature: float,
+        temperature: float | torch.Tensor,
         epsilon: float,
         debug: bool = False,
     ) -> torch.Tensor:
@@ -810,7 +830,7 @@ class DiscretePolicyEstimator(PolicyMixin, LogitBasedEstimator):
         states: DiscreteStates,
         module_output: torch.Tensor,
         sf_bias: float = 0.0,
-        temperature: float = 1.0,
+        temperature: float | torch.Tensor = 1.0,
         epsilon: float = 0.0,
     ) -> Categorical:
         """Returns a Categorical distribution given a batch of states and module output.
@@ -843,7 +863,10 @@ class DiscretePolicyEstimator(PolicyMixin, LogitBasedEstimator):
                 f"Module output shape {module_output.shape} does not match "
                 f"expected output dimension {self.expected_output_dim}"
             )
-            assert temperature > 0.0
+            if isinstance(temperature, torch.Tensor):
+                assert torch.all(temperature > 0.0)
+            else:
+                assert temperature > 0.0
             assert 0.0 <= epsilon <= 1.0
 
         logits = LogitBasedEstimator._compute_logits_for_distribution(


### PR DESCRIPTION
## Summary

This PR extends discrete policy sampling so callers can provide a state-dependent sampling temperature instead of only a scalar temperature.

Concretely, it:

- lets `PolicyMixin` and `RecurrentPolicyMixin` accept `policy_kwargs["temperature"]` as a callable
- calls that temperature function after estimator outputs are available, with `(states_active, estimator_outputs)`
- allows `LogitBasedEstimator` / `DiscretePolicyEstimator` temperature to be either a scalar float or a tensor
- broadcasts tensor temperatures across the action/logit dimension before dividing logits
- preserves the existing scalar-temperature path unchanged

## Motivation

The downstream `gfn-communities` novelty-guidance work needs local, per-state adaptive temperature during trajectory sampling. The sampler already threads `temperature` through `policy_kwargs`; this change makes that hook expressive enough for per-step, state-conditioned temperature without forcing downstream code to fork the sampler or estimator stack.

## Behavioral Compatibility

- Existing scalar `temperature=1.0` and `temperature=<float>` behavior is unchanged.
- Callable temperature is opt-in. If `temperature` is not callable, the old path is used.
- Tensor temperature is opt-in. Scalar comparisons/assertions are preserved for scalar values, while tensor values assert all entries are positive.
- The tensor path only changes logits by dividing by a broadcasted positive tensor.

## Testing

Local smoke run from the downstream environment:

```bash
PYTHONPATH=src /home/mila/m/minsu.kim/.conda/envs/gfn-communities/bin/python - <<'PY'
import torch
from gfn.estimators import LogitBasedEstimator
logits = torch.tensor([[1.0, 2.0], [3.0, 5.0]])
masks = torch.ones_like(logits, dtype=torch.bool)
out = LogitBasedEstimator._prepare_logits(
    logits, masks, sf_index=None, sf_bias=0.0, temperature=torch.tensor([1.0, 2.0])
)
assert torch.allclose(out[0], logits[0])
assert torch.allclose(out[1], logits[1] / 2.0)
scalar = LogitBasedEstimator._prepare_logits(
    logits, masks, sf_index=None, sf_bias=0.0, temperature=2.0
)
assert torch.allclose(scalar, logits / 2.0)
print('tensor/scalar temperature smoke passed')
PY
```

Output:

```text
tensor/scalar temperature smoke passed
```

## Downstream Dependency

This PR is required by the `gfn-communities` adaptive-temperature novelty guidance implementation. The downstream core PR intentionally keeps the submodule pointer unchanged until this lands in `GFNOrg/torchgfn`; after merge, the submodule pointer should be updated in a follow-up.
