### PR TITLE
Add K-rule trunk+heads structure to compositional hypergrid rewards

### DIFF
--- a/src/gfn/gym/hypergrid.py
+++ b/src/gfn/gym/hypergrid.py
@@ -450,16 +450,21 @@ class HyperGrid(DiscreteEnv):
             return self.reward_fn.mode_threshold()
 
         # For other compositional rewards with tiered structure, mark mode as
-        # achieving the highest tier.
-        if isinstance(
-            self.reward_fn,
-            (BitwiseXORReward, MultiplicativeCoprimeReward),
-        ):
-            r0 = float(getattr(self.reward_fn, "R0", 0.0))
-            tw = getattr(self.reward_fn, "tier_weights", [])
-            if not isinstance(tw, (list, tuple)) or len(tw) == 0:
+        # achieving the highest tier (plus head bonus for K-rule bitxor).
+        if isinstance(self.reward_fn, BitwiseXORReward):
+            r0 = float(self.reward_fn.R0)
+            tw = self.reward_fn.tier_weights
+            if len(tw) == 0:
                 raise ValueError(
-                    "Tiered reward missing `tier_weights`; cannot derive mode threshold."
+                    "BitwiseXORReward missing `tier_weights`; cannot derive mode threshold."
+                )
+            return r0 + float(sum(tw)) + float(self.reward_fn.head_weight)
+        if isinstance(self.reward_fn, MultiplicativeCoprimeReward):
+            r0 = float(self.reward_fn.R0)
+            tw = self.reward_fn.tier_weights
+            if len(tw) == 0:
+                raise ValueError(
+                    "MultiplicativeCoprimeReward missing `tier_weights`; cannot derive mode threshold."
                 )
             return r0 + float(sum(tw))
 
@@ -704,6 +709,8 @@ class HyperGrid(DiscreteEnv):
             return self._exists_bitwise_xor(thr)
         if isinstance(self.reward_fn, MultiplicativeCoprimeReward):
             return self._exists_multiplicative_coprime(thr)
+        if isinstance(self.reward_fn, ConditionalMultiScaleReward):
+            return self._exists_conditional_multiscale(thr)
         return self._exists_fallback_random(thr)
 
     def _modes_exist_quick_check_info(self) -> tuple[bool, str]:
@@ -822,81 +829,175 @@ class HyperGrid(DiscreteEnv):
     def _exists_bitwise_xor(self, thr: float) -> bool:
         """Feasibility and constructive check for ``BitwiseXORReward``.
 
-        Steps:
-        - Verify the combined GF(2) system (full_A @ x = full_c) has at
-          least one solution using Gaussian elimination modulo 2.
-        - Try the all-zero configuration first (satisfies default even
-          parity). If that fails, try a small batch of random states.
+        Builds the combined GF(2) system [trunk; selector→0; head_0]·b =
+        [c_trunk; 0; c_head_0] for rule 0 and verifies consistency. This works
+        uniformly for n_rules=1 (k_select=0, selector empty) and for K-rule
+        (per-rule coverage was already verified at __init__ by
+        _validate_rule_coverage; this re-checks rule 0 as a defense-in-depth).
+
+        If the GF(2) system is consistent the reward attains R0 + sum(tier_w)
+        + head_weight on at least one state, which equals the mode threshold.
         """
-        # Check that the combined system is feasible.
         rf = self.reward_fn
-        if rf._full_A.shape[0] > 0:
-            if not self._solve_gf2_has_solution(rf._full_A, rf._full_c):
-                return False
-
-        # Try all-zero first.
-        x = torch.zeros(self.ndim, dtype=torch.long)
-        r = float(rf(x.unsqueeze(0))[0])
-        if r >= thr - EPS_REWARD_CMP:
+        sel_c = torch.zeros(rf.k_select, dtype=torch.long)
+        head_A_0 = rf._head_A_per_rule[0]
+        head_c_0 = rf._head_c_per_rule[0]
+        full_A = torch.cat([rf._full_A, rf._selector_matrix, head_A_0], dim=0)
+        full_c = torch.cat([rf._full_c, sel_c, head_c_0], dim=0)
+        if full_A.numel() == 0:
             return True
-
-        # Try a small random batch as fallback.
-        return self._exists_fallback_random(thr)
+        return self._solve_gf2_has_solution(full_A, full_c)
 
     def _exists_multiplicative_coprime(self, thr: float) -> bool:
         """Number-theoretic constructive check for ``MultiplicativeCoprimeReward``.
 
-        Constructs a candidate state by factoring the target LCM (if any) over
-        the allowed primes, assigning each prime power to a separate active
-        dimension, and verifying coprimality and grid-bound constraints.
+        For each rule, factors the rule's target LCM over allowed primes,
+        tries permutations of prime-to-active-dim assignments, and checks
+        coprime + grid-bound + selector-match. Returns True iff at least one
+        rule has a witness state whose selector maps back to that rule's
+        index AND whose reward reaches the mode threshold.
+
+        At n_rules=1 the selector is trivially 0 and only rule 0 is tried,
+        recovering the legacy behavior.
         """
-        primes: list[int] = [int(p) for p in self.reward_fn.primes]
-        caps: list[int] = [int(c) for c in self.reward_fn.exponent_caps]
-        active = list(self.reward_fn.active_dims)
-        coprime_pairs = self.reward_fn.coprime_pairs or []
+        rf = self.reward_fn
+        primes: list[int] = [int(p) for p in rf.primes]
+        caps: list[int] = [int(c) for c in rf.exponent_caps]
+        active = list(rf.active_dims)
+        coprime_pairs = rf.coprime_pairs or []
         max_exponent = int(caps[-1])
-        target_lcms = self.reward_fn.target_lcms
-        target = None if target_lcms is None else target_lcms[-1]
+        rule_targets = rf.rule_targets
 
-        # Start with all-ones (valid for prime-support: 1 has zero exponents).
-        x = torch.ones(self.ndim, dtype=torch.long)
-
-        if target is not None:
-            target = int(target)
-
-            # Factor target LCM over the allowed primes.
-            required_prime_powers: list[tuple[int, int]] = []
-            unfactored_remainder = target
+        # No per-rule head targets → mode is determined by trunk's tier-T
+        # target_lcms[-1] (or trivially the all-zeros state if both are None).
+        # In this regime we ignore the selector match (head trivially passes
+        # for every rule), so any state achieving the trunk LCM is a witness.
+        if not rule_targets or all(t is None for t in rule_targets):
+            trunk_target = rf.target_lcms[-1] if rf.target_lcms else None
+            if trunk_target is None:
+                x = torch.zeros(self.ndim, dtype=torch.long)
+                r = float(rf(x.unsqueeze(0))[0])
+                return r >= thr - EPS_REWARD_CMP
+            # Factor trunk_target and search permutations like the per-rule
+            # branch, but with no selector constraint.
+            required: list[tuple[int, int]] = []
+            remaining = int(trunk_target)
             for p in primes:
                 exp = 0
-                while unfactored_remainder % p == 0:
-                    unfactored_remainder //= p
+                while remaining % p == 0:
+                    remaining //= p
                     exp += 1
                 if exp > 0:
-                    if exp > max_exponent or (p**exp) > (self.height - 1):
+                    if exp > max_exponent or (p**exp) > self.height:
                         return False
-                    required_prime_powers.append((p, exp))
-
-            # All prime factors must come from the allowed set.
-            if unfactored_remainder != 1:
+                    required.append((p, exp))
+            if remaining != 1 or len(required) > len(active):
                 return False
-            # Need at most one dimension per distinct prime power.
-            if len(required_prime_powers) > len(active):
-                return False
-
-            # Assign each prime power to a separate active dimension.
-            for (p, exp), dim in zip(required_prime_powers, active):
-                x[dim] = p**exp
-
-            # Verify that dimension pairs designated as coprime have gcd == 1.
-            for i, j in coprime_pairs:
-                if torch.gcd(x[active[i]], x[active[j]]).item() != 1:
-                    return False
-
-        if int(x.max()) >= self.height:
+            for perm in itertools.permutations(active, len(required)):
+                x = torch.zeros(self.ndim, dtype=torch.long)
+                for (p, e), dim in zip(required, perm):
+                    x[dim] = p**e - 1
+                if int(x.max()) >= self.height:
+                    continue
+                coprime_ok = True
+                for i, j in coprime_pairs:
+                    if i >= len(active) or j >= len(active):
+                        continue
+                    vi = int(x[active[i]]) + 1
+                    vj = int(x[active[j]]) + 1
+                    if math.gcd(vi, vj) != 1:
+                        coprime_ok = False
+                        break
+                if not coprime_ok:
+                    continue
+                r = float(rf(x.unsqueeze(0))[0])
+                if r >= thr - EPS_REWARD_CMP:
+                    return True
             return False
-        r = float(self.reward_fn(x.unsqueeze(0))[0])
-        return r >= thr - EPS_REWARD_CMP
+
+        for k, target in enumerate(rule_targets):
+            if target is None:
+                # Rule with no LCM constraint passes head trivially. Try
+                # all-zeros and check selector.
+                x = torch.zeros(self.ndim, dtype=torch.long)
+                if int(rf._selector((x[active] + 1).unsqueeze(0))[0]) == k:
+                    r = float(rf(x.unsqueeze(0))[0])
+                    if r >= thr - EPS_REWARD_CMP:
+                        return True
+                continue
+
+            # Factor target LCM over allowed primes.
+            required: list[tuple[int, int]] = []
+            remaining = int(target)
+            for p in primes:
+                exp = 0
+                while remaining % p == 0:
+                    remaining //= p
+                    exp += 1
+                if exp > 0:
+                    if exp > max_exponent or (p**exp) > self.height:
+                        break
+                    required.append((p, exp))
+            else:
+                if remaining != 1 or len(required) > len(active):
+                    continue
+                # Try permutations of prime → dim assignment until one matches
+                # the selector and passes coprime/grid constraints.
+                for perm in itertools.permutations(active, len(required)):
+                    x = torch.zeros(self.ndim, dtype=torch.long)
+                    for (p, e), dim in zip(required, perm):
+                        x[dim] = p**e - 1
+                    if int(x.max()) >= self.height:
+                        continue
+                    # Coprime check on post-shift values.
+                    coprime_ok = True
+                    for i, j in coprime_pairs:
+                        if i >= len(active) or j >= len(active):
+                            continue
+                        vi = int(x[active[i]]) + 1
+                        vj = int(x[active[j]]) + 1
+                        if math.gcd(vi, vj) != 1:
+                            coprime_ok = False
+                            break
+                    if not coprime_ok:
+                        continue
+                    # Selector must map back to this rule.
+                    if int(rf._selector((x[active] + 1).unsqueeze(0))[0]) != k:
+                        continue
+                    r = float(rf(x.unsqueeze(0))[0])
+                    if r >= thr - EPS_REWARD_CMP:
+                        return True
+        return False
+
+    def _exists_conditional_multiscale(self, thr: float) -> bool:
+        """Constructive existence check for ConditionalMultiScaleReward.
+
+        With filter_shift=[0,...,0] (default) the all-zeros state is always a
+        mode: every per-tier filter passes 0 since (0 + 0) mod B = 0 < f. With
+        non-zero filter_shift, we try a few "all-same-v" candidate states
+        chosen so the MSD passes tier 0; one of them typically passes all
+        deeper tiers when the per-rule shift_coeffs map zero lower digits to
+        zero, leaving the constant filter_shift[t] as the only contribution.
+        """
+        rf = self.reward_fn
+        with torch.no_grad():
+            # Try all-same v over digit values that pass tier 0's filter.
+            # MSD passes iff (msd + filter_shift[0]) mod B < f.
+            base = rf.base
+            f = rf.filter_width
+            fs0 = rf.filter_shift[0] if hasattr(rf, "filter_shift") else 0
+            msb_factor = base ** (rf.num_levels - 1)
+            for msd in range(base):
+                if (msd + fs0) % base >= f:
+                    continue
+                v = msd * msb_factor
+                xs = torch.full(
+                    (1, self.ndim), v, dtype=torch.long, device=torch.device("cpu")
+                )
+                r = rf(xs)[0].item()
+                if r >= thr - EPS_REWARD_CMP:
+                    return True
+        return self._exists_fallback_random(thr)
 
     def _exists_fallback_random(self, thr: float) -> bool:
         """Random sampling fallback.
@@ -911,6 +1012,54 @@ class HyperGrid(DiscreteEnv):
             xs = torch.randint(0, self.height, (B, self.ndim), device=device)
             rr = self.reward_fn(xs)
             return bool((rr >= thr - EPS_REWARD_CMP).any().item())
+
+    @staticmethod
+    def _solve_gf2_witness(
+        A: torch.Tensor, c: torch.Tensor, n_vars: int
+    ) -> torch.Tensor | None:
+        """Return a witness solution to A·b = c over GF(2), or None if none exists.
+
+        b has length n_vars. A is reduced via Gaussian elimination; free
+        variables are set to 0.
+        """
+        if A.numel() == 0:
+            return torch.zeros(n_vars, dtype=torch.long)
+        A = A.clone().detach().to(dtype=torch.uint8, device=torch.device("cpu")) & 1
+        c = c.clone().detach().to(dtype=torch.uint8, device=torch.device("cpu")) & 1
+
+        n_eq, n_vars_check = A.shape
+        assert n_vars == n_vars_check
+        pivot_cols: list[int] = []
+        pivot_row = 0
+        for col in range(n_vars):
+            cand = None
+            for r in range(pivot_row, n_eq):
+                if A[r, col]:
+                    cand = r
+                    break
+            if cand is None:
+                continue
+            if cand != pivot_row:
+                A[[pivot_row, cand]] = A[[cand, pivot_row]]
+                c[[pivot_row, cand]] = c[[cand, pivot_row]]
+            for r in range(n_eq):
+                if r != pivot_row and A[r, col]:
+                    A[r] ^= A[pivot_row]
+                    c[r] ^= c[pivot_row]
+            pivot_cols.append(col)
+            pivot_row += 1
+            if pivot_row == n_eq:
+                break
+
+        # Inconsistent if any zero row has nonzero RHS.
+        for r in range(pivot_row, n_eq):
+            if c[r]:
+                return None
+
+        b = torch.zeros(n_vars, dtype=torch.long)
+        for r, col in enumerate(pivot_cols):
+            b[col] = int(c[r])
+        return b
 
     @staticmethod
     def _solve_gf2_has_solution(A: torch.Tensor, c: torch.Tensor) -> bool:
@@ -1403,6 +1552,28 @@ class BitwiseXORReward(GridReward):
     and the number of constrained dimensions. Typical distance from origin for
     valid modes scales roughly like (constrained_dims · 2^{highest_bit}).
 
+    K-rule structure (n_rules >= 1):
+        - Trunk: the per-tier parity stack above, shared across all rules.
+        - Selector: a fixed GF(2) matrix S of shape (k_select, M*B) projects
+          bits to a rule index r = pack(S·b mod 2) ∈ [0, n_rules). Here
+          k_select = ceil(log2(n_rules)); for n_rules=1, k_select=0 and r is
+          always 0.
+        - Head: per-rule parity matrix H_r of shape (head_check_count, M),
+          applied at every bit-plane in head_bit_range. Mode iff trunk passes
+          AND H_r·b == c_r at the head's bit-planes.
+
+        Reward:
+            R = R0 + Σ_t w_t·1[trunk_0..t pass]
+                  + head_weight · 1[trunk all pass ∧ head_{σ(b)} pass]
+
+        At n_rules=1 with head_check_count=0 and head_weight=0 (defaults), the
+        head is empty and the K-rule code path collapses to the legacy reward
+        bit-exactly.
+
+        Total mode count is invariant in n_rules when it's a power of 2 — the
+        selector adds k_select bits that partition the trunk-passing space,
+        and per-rule head adds head_check_count·n_head_bits bits per coset.
+
     Comparison with other compositional rewards:
         - MultiplicativeCoprimeReward: number-theoretic (prime factorization);
           knowledge composition — learning prime structure enables coprimality
@@ -1414,6 +1585,8 @@ class BitwiseXORReward(GridReward):
           parity check type is applied with increasing strictness per tier.
           Modes are non-local (algebraic, not spatial).
     """
+
+    _RULE_SEED_STRIDE: int = 1_000_003
 
     def __init__(self, height: int, ndim: int, **kwargs):
         super().__init__(height, ndim, **kwargs)
@@ -1549,6 +1722,243 @@ class BitwiseXORReward(GridReward):
                 )
                 break
 
+        # --- K-rule selector + per-rule heads ---
+        self.n_rules: int = int(kwargs.get("n_rules", 1))
+        assert self.n_rules >= 1, f"n_rules must be >= 1, got {self.n_rules}"
+        self.head_check_count: int = int(kwargs.get("head_check_count", 0))
+        head_seed = kwargs.get("head_seed", None)
+        # head_seed is required whenever K-rule structure is non-trivial:
+        # either n_rules > 1 (selector exists) or head_check_count > 0 (head matrix).
+        if head_seed is None and (self.n_rules > 1 or self.head_check_count > 0):
+            raise ValueError(
+                "head_seed must be provided when n_rules > 1 or "
+                f"head_check_count > 0; got None (n_rules={self.n_rules}, "
+                f"head_check_count={self.head_check_count})."
+            )
+        self.head_seed: int = int(head_seed) if head_seed is not None else 0
+        self.head_weight: float = float(kwargs.get("head_weight", 0.0))
+        if self.head_check_count == 0 and self.head_weight != 0.0:
+            raise ValueError(
+                "head_weight is non-zero but head_check_count=0; head will "
+                "always pass and contribute trivially. Set head_check_count > 0."
+            )
+        head_bit_range = kwargs.get("head_bit_range", None)
+        if head_bit_range is None:
+            head_bit_range = (0, B - 1) if self.head_check_count > 0 else (0, -1)
+        self.head_bit_range: tuple[int, int] = (
+            int(head_bit_range[0]),
+            int(head_bit_range[1]),
+        )
+        if self.head_check_count > 0:
+            assert self.head_bit_range[0] <= self.head_bit_range[1], (
+                f"head_bit_range={self.head_bit_range} is empty but "
+                f"head_check_count={self.head_check_count} > 0."
+            )
+        self.k_select: int = (
+            int(math.ceil(math.log2(self.n_rules))) if self.n_rules > 1 else 0
+        )
+
+        # Build selector matrix (shared across rules). Re-seed up to a few
+        # times if the random selector accidentally aligns with the trunk
+        # (rank deficient combined system). At M*B >= 16 + k_select this is
+        # rare in practice, but assert independence loudly if it persists.
+        if self.k_select > 0:
+            trunk_rank_for_indep = (
+                _gf2_rank(self._full_A) if self._full_A.numel() > 0 else 0
+            )
+            for attempt in range(8):
+                S, _ = _gf2_random_fullrank(
+                    self.k_select,
+                    M * B,
+                    self.head_seed + attempt * self._RULE_SEED_STRIDE,
+                )
+                S_long = S.long()
+                if self._full_A.numel() == 0:
+                    combined_rank = _gf2_rank(S_long)
+                else:
+                    combined_rank = _gf2_rank(
+                        torch.cat([self._full_A, S_long], dim=0)
+                    )
+                if combined_rank == trunk_rank_for_indep + self.k_select:
+                    break
+            else:
+                raise ValueError(
+                    f"BitwiseXORReward: could not find a selector matrix "
+                    f"linearly independent of the trunk after 8 attempts "
+                    f"(head_seed={self.head_seed}). Trunk rank={trunk_rank_for_indep}, "
+                    f"k_select={self.k_select}, M*B={M*B}."
+                )
+            self._selector_matrix = S_long
+        else:
+            self._selector_matrix = torch.zeros(0, M * B, dtype=torch.long)
+
+        # Build head_A (shared across rules) and per-rule head_c. Sharing head_A
+        # guarantees uniform per-rule mode count (rank is invariant in c). Per-
+        # rule head_c is constructed from a witness b_rule that solves
+        # trunk + selector→rule, so the combined system is consistent for every
+        # rule by construction.
+        lo_h, hi_h = self.head_bit_range
+        n_head_bits = max(0, hi_h - lo_h + 1)
+        r_head_total = self.head_check_count * n_head_bits
+        self._head_c_per_rule = torch.zeros(
+            self.n_rules, r_head_total, dtype=torch.long
+        )
+        if self.head_check_count > 0 and n_head_bits > 0:
+            A_r, _ = _gf2_random_fullrank(
+                self.head_check_count, M, self.head_seed + self._RULE_SEED_STRIDE
+            )
+            self._head_A = torch.zeros(r_head_total, M * B, dtype=torch.long)
+            row = 0
+            for bb in range(lo_h, hi_h + 1):
+                for cd in range(M):
+                    self._head_A[row : row + self.head_check_count, cd * B + bb] = (
+                        A_r[:, cd].long()
+                    )
+                row += self.head_check_count
+            # Per-rule head_c via witness construction.
+            for rule in range(self.n_rules):
+                sel_target = torch.tensor(
+                    [(rule >> i) & 1 for i in range(self.k_select)], dtype=torch.long
+                )
+                witness_A = torch.cat([self._full_A, self._selector_matrix], dim=0)
+                witness_c = torch.cat([self._full_c, sel_target], dim=0)
+                b_rule = HyperGrid._solve_gf2_witness(witness_A, witness_c, M * B)
+                if b_rule is None:
+                    raise ValueError(
+                        f"BitwiseXORReward: rule {rule} has no solution under "
+                        f"trunk + selector. Cannot construct head_c. "
+                        f"Reduce trunk strictness or change head_seed."
+                    )
+                self._head_c_per_rule[rule] = (self._head_A @ b_rule.long()) & 1
+        else:
+            self._head_A = torch.zeros(0, M * B, dtype=torch.long)
+
+        # Stack head_A into per-rule shape (n_rules, r_head_total, M*B) for
+        # batched gather in __call__. All rules share the same A matrix.
+        self._head_A_per_rule = self._head_A.unsqueeze(0).expand(
+            self.n_rules, -1, -1
+        ).contiguous()
+
+        # Powers of 2 for packing selector bits to rule_idx.
+        self._select_powers = (
+            torch.tensor([2**i for i in range(self.k_select)], dtype=torch.long)
+            if self.k_select > 0
+            else torch.zeros(0, dtype=torch.long)
+        )
+
+        # Run validator whenever K-rule structure is non-trivial. Covers the
+        # K=1-with-head case too (single rule but witness construction must
+        # have succeeded for the head_c[0] to be feasible).
+        self._uniform_partition: bool = True
+        if self.n_rules > 1 or self._head_A_per_rule.shape[1] > 0:
+            self._validate_rule_coverage()
+
+    def _validate_rule_coverage(self) -> None:
+        """Ensure every rule index has >= 1 mode (trunk + selector→rule + head_rule).
+
+        For each rule k, build the combined GF(2) system:
+            [H_trunk; S; H_k] · b = [c_trunk; pack^-1(k); c_k]
+        and verify it's consistent via _solve_gf2_has_solution. With k_select
+        bits encoding the rule index, the selector contributes k_select scalar
+        equations whose RHS is determined by the rule.
+
+        Also tracks _uniform_partition: True iff n_rules is a power of 2 AND
+        the combined trunk+selector matrix has rank r_trunk + k_select (i.e.
+        the selector is independent of the trunk, so each rule is reachable
+        with the same per-rule mode count).
+        """
+        trunk_A = self._full_A
+        trunk_c = self._full_c
+        S = self._selector_matrix
+        for rule in range(self.n_rules):
+            sel_bits = [(rule >> i) & 1 for i in range(self.k_select)]
+            sel_c = torch.tensor(sel_bits, dtype=torch.long)
+            head_A = self._head_A_per_rule[rule]
+            head_c = self._head_c_per_rule[rule]
+            full_A = torch.cat([trunk_A, S, head_A], dim=0)
+            full_c = torch.cat([trunk_c, sel_c, head_c], dim=0)
+            if not HyperGrid._solve_gf2_has_solution(full_A, full_c):
+                raise ValueError(
+                    f"BitwiseXORReward: rule {rule} has no solution "
+                    f"(combined trunk + selector + head is inconsistent over GF(2)). "
+                    f"Reduce head_check_count or change head_seed."
+                )
+
+        # Uniform partition iff every rule has the same per-rule mode count.
+        # This subsumes power-of-2 + selector-rank-independence and also
+        # catches incidental rank deficiency in head_k for some rules.
+        per_rule = self._per_rule_mode_counts()
+        self._uniform_partition = len(set(per_rule)) == 1
+        if not self._uniform_partition:
+            logger.warning(
+                "BitwiseXORReward: K-rule partition is not uniform "
+                "(per-rule mode counts: %s). "
+                "analytic_mode_count(per_rule=True) will raise.",
+                per_rule,
+            )
+
+    def analytic_mode_count(self, per_rule: bool = False) -> int:
+        """Total mode count via per-rule GF(2) rank summation.
+
+        For each rule k, modes_k = 2^(M·B − rank([trunk; selector; head_k])).
+        Total = Σ_k modes_k. With random full-rank head matrices the per-rule
+        ranks coincide and total = K · modes_0; for small or degenerate
+        configurations they may differ. Multiplied by H^(ndim − M) for
+        unconstrained dims.
+        """
+        M = len(self.dims_constrained)
+        B = self._B
+        n_vars = M * B
+        unconstrained = self.height ** (self.ndim - M)
+        per_rule_counts = self._per_rule_mode_counts()
+        total = sum(per_rule_counts) * unconstrained
+
+        if per_rule:
+            if not self._uniform_partition:
+                raise ValueError(
+                    "analytic_mode_count(per_rule=True) requires a uniform "
+                    "K-partition; per-rule mode counts differ."
+                )
+            return per_rule_counts[0] * unconstrained
+        return total
+
+    def _per_rule_mode_counts(self) -> list[int]:
+        """Bit-config mode count per rule (without unconstrained-dim factor).
+
+        For rule k, returns 2^(M·B − rank([trunk; selector; head_k])) when
+        the combined system is consistent, else 0. Inconsistency means the
+        rule is unreachable — its bit-config mode count is 0.
+        """
+        M = len(self.dims_constrained)
+        B = self._B
+        n_vars = M * B
+        if self.n_rules == 1 and self._head_A_per_rule.shape[1] == 0:
+            if self._full_A.numel() == 0:
+                return [2**n_vars]
+            if not HyperGrid._solve_gf2_has_solution(self._full_A, self._full_c):
+                return [0]
+            return [2 ** (n_vars - _gf2_rank(self._full_A))]
+        counts = []
+        for r in range(self.n_rules):
+            sel_target = torch.tensor(
+                [(r >> i) & 1 for i in range(self.k_select)], dtype=torch.long
+            )
+            A = torch.cat(
+                [self._full_A, self._selector_matrix, self._head_A_per_rule[r]],
+                dim=0,
+            )
+            c = torch.cat(
+                [self._full_c, sel_target, self._head_c_per_rule[r]], dim=0
+            )
+            if A.numel() == 0:
+                counts.append(2**n_vars)
+                continue
+            if not HyperGrid._solve_gf2_has_solution(A, c):
+                counts.append(0)
+                continue
+            counts.append(2 ** (n_vars - _gf2_rank(A)))
+        return counts
+
     def _even_parity_mask(self, bits: torch.Tensor) -> torch.Tensor:
         """bits: (..., m) int/bool -> returns (...,) bool for even parity."""
         if bits.dtype != torch.long:
@@ -1597,10 +2007,10 @@ class BitwiseXORReward(GridReward):
         all_bits = (x.unsqueeze(-1) >> bit_positions) & 1
         flat_bits = all_bits.reshape(*x.shape[:-1], -1).long()
 
-        # Single matmul: all GF(2) checks
+        # Single matmul: all GF(2) trunk checks
         prod = (flat_bits @ full_A.t()) & 1
 
-        # Tiered reward accumulation
+        # Tiered reward accumulation (trunk)
         R = torch.full(
             x.shape[:-1],
             self.R0,
@@ -1617,6 +2027,30 @@ class BitwiseXORReward(GridReward):
                 tier_ok = tier_ok & slice_ok
             R = R + tier_ok.to(R.dtype) * w
             offset += n_chk
+
+        # K-rule head: selector projects bits to rule_idx (or 0 at K=1);
+        # head_{rule_idx} adds an extra parity check that must also pass for
+        # head_weight. No-op when head matrices are empty.
+        if self._head_A_per_rule.shape[1] > 0:
+            if self.k_select > 0:
+                S = self._selector_matrix.to(dev)
+                select_powers = self._select_powers.to(dev)
+                sel_bits = (flat_bits @ S.t()) & 1
+                rule_idx = (sel_bits * select_powers).sum(dim=-1) % self.n_rules
+            else:
+                rule_idx = torch.zeros(x.shape[:-1], device=dev, dtype=torch.long)
+
+            head_A = self._head_A_per_rule.to(dev)
+            head_c = self._head_c_per_rule.to(dev)
+            A_per_state = head_A[rule_idx]
+            c_per_state = head_c[rule_idx]
+            head_prod = (
+                torch.einsum("...rj,...j->...r", A_per_state, flat_bits) & 1
+            )
+            head_ok = (head_prod == c_per_state).all(-1)
+
+            R = R + (tier_ok & head_ok).to(R.dtype) * self.head_weight
+
         return R
 
 
@@ -1757,6 +2191,170 @@ class MultiplicativeCoprimeReward(GridReward):
             else:
                 self.target_lcms.append(None)
 
+        # --- K-rule selector + per-rule top-tier LCM heads ---
+        # Trunk = tiers 0..T-2 (existing behavior). Head = tier T-1, replaced
+        # per-rule by rule_targets[selector(state)]. Three resolution paths:
+        #   1. Explicit `rule_targets` kwarg → use as-is.
+        #   2. Explicit `head_seed` kwarg → generate K targets from head_seed
+        #      (this is the K-rule path; works for K=1 too).
+        #   3. Neither → backward-compat: inherit from target_lcms[T-1] (for
+        #      n_rules=1; n_rules>1 without head_seed already raised above).
+        self.n_rules: int = int(kwargs.get("n_rules", 1))
+        assert self.n_rules >= 1, f"n_rules must be >= 1, got {self.n_rules}"
+        head_seed_provided = kwargs.get("head_seed", None) is not None
+        if not head_seed_provided and self.n_rules > 1:
+            raise ValueError(
+                "head_seed must be provided when n_rules > 1; got None."
+            )
+        self.head_seed: int = (
+            int(kwargs["head_seed"]) if head_seed_provided else 0
+        )
+
+        rule_targets = kwargs.get("rule_targets", None)
+        rule_targets_inherited_from_trunk = False
+        if rule_targets is None:
+            if head_seed_provided:
+                rule_targets = self._generate_rule_targets(
+                    self.n_rules, self.head_seed
+                )
+            else:
+                # Legacy K=1 backward-compat: head's single LCM mirrors the
+                # trunk's top-tier LCM. Mark as inherited so we don't later
+                # clear target_lcms[-1] (the redundancy is harmless and
+                # preserving it keeps pre-refactor reward output bit-exact).
+                rule_targets = [self.target_lcms[-1]]
+                rule_targets_inherited_from_trunk = True
+        assert len(rule_targets) == self.n_rules, (
+            f"rule_targets has {len(rule_targets)} entries; expected n_rules={self.n_rules}"
+        )
+        self.rule_targets: list[int | None] = [
+            int(t) if t is not None else None for t in rule_targets
+        ]
+
+        # Clear the shared trunk top-tier LCM only when the head replaces it
+        # with non-trivial per-rule LCMs that *differ* from the trunk's.
+        # - Legacy K=1 (no head_seed): rule_targets inherited from trunk —
+        #   keep target_lcms[-1] (redundancy is harmless, bit-exact compat).
+        # - K-rule with auto-gen or explicit rule_targets: clear to avoid the
+        #   trunk LCM conflicting with rule-specific head LCMs (B1 fix).
+        # - Selector-only K-rule (rule_targets=[None]*K): keep target_lcms[-1]
+        #   so the trunk LCM still constrains modes.
+        head_has_lcm = any(t is not None for t in self.rule_targets)
+        if head_has_lcm and not rule_targets_inherited_from_trunk:
+            self.target_lcms[-1] = None
+
+        # Pre-factor each rule's target_lcm into prime exponents, for fast
+        # per-state gather in __call__. Shape: (n_rules, n_primes).
+        # Rule with target=None uses sentinel exponents of -1 (always passes).
+        n_primes = len(self.primes)
+        self._rule_target_exps = torch.full(
+            (self.n_rules, n_primes), -1, dtype=torch.long
+        )
+        for r, T in enumerate(self.rule_targets):
+            if T is None:
+                continue
+            remaining = int(T)
+            for j, p in enumerate(self.primes):
+                e = 0
+                while remaining % p == 0:
+                    remaining //= p
+                    e += 1
+                self._rule_target_exps[r, j] = e
+            if remaining != 1:
+                raise ValueError(
+                    f"rule_targets[{r}]={T} contains primes outside the "
+                    f"allowed set {self.primes}."
+                )
+
+        if self.n_rules > 1:
+            self._validate_rule_coverage()
+
+    def _generate_rule_targets(self, n_rules: int, seed: int) -> list[int]:
+        """Generate n_rules distinct LCM targets from a deterministic enum.
+
+        Enumerates cap-tuples (cap_p ∈ {1, ..., top_cap}) over allowed primes —
+        cap=0 (prime absent from LCM) is excluded so every rule has a
+        non-trivial target. Total tuples = top_cap^n_primes; permutes by seed
+        and picks the first n_rules. The prime universe must satisfy
+        top_cap^n_primes >= n_rules.
+
+        Note: cap=0 is intentionally excluded. With cap=0, the LCM head
+        constraint "no active dim has prime p as factor" combined with
+        coprime-pair and exponent-cap constraints typically yields zero or
+        near-zero modes — degenerate rules.
+        """
+        if not self.primes:
+            raise ValueError(
+                "Cannot generate rule_targets: no allowed primes for height."
+            )
+        n_primes = len(self.primes)
+        top_cap = self.exponent_caps[-1]
+        if top_cap < 1:
+            raise ValueError(
+                f"Cannot generate rule_targets: top exponent_cap={top_cap} < 1."
+            )
+        n_cap_values = top_cap  # caps in {1, ..., top_cap}
+        n_total = n_cap_values**n_primes
+        if n_total < n_rules:
+            raise ValueError(
+                f"Cannot generate {n_rules} distinct LCMs with {n_primes} primes "
+                f"and cap_p ∈ {{1..{top_cap}}}: {n_cap_values}^{n_primes}={n_total}."
+            )
+        all_tuples: list[int] = []
+        for idx in range(n_total):
+            rem = idx
+            caps: list[int] = []
+            for _ in range(n_primes):
+                caps.append((rem % n_cap_values) + 1)  # shift to {1..top_cap}
+                rem //= n_cap_values
+            lcm = 1
+            for p, c in zip(self.primes, caps):
+                lcm *= p**c
+            all_tuples.append(lcm)
+        gen = torch.Generator().manual_seed(seed)
+        perm = torch.randperm(n_total, generator=gen).tolist()
+        return [all_tuples[perm[i]] for i in range(n_rules)]
+
+    def _validate_rule_coverage(self) -> None:
+        """Ensure each rule's LCM target is achievable.
+
+        A target is achievable iff (a) it factors over allowed primes (already
+        checked at __init__), and (b) every required exponent is <= top cap.
+        Both conditions are necessary; with active_dims >= n_primes_with_nonzero_exp
+        and coprime_pairs constraints, sufficiency requires enumeration.
+        Here we check only the necessary conditions and verify that the rules
+        produce non-degenerate distinct targets.
+        """
+        top_cap = self.exponent_caps[-1]
+        seen = set()
+        for r, exps in enumerate(self._rule_target_exps.tolist()):
+            if all(e == -1 for e in exps):
+                continue
+            for j, e in enumerate(exps):
+                if e > top_cap:
+                    raise ValueError(
+                        f"rule_targets[{r}] requires exponent {e} for prime "
+                        f"{self.primes[j]}, exceeding top cap {top_cap}."
+                    )
+            tup = tuple(exps)
+            seen.add(tup)
+        if len(seen) < self.n_rules:
+            logger.warning(
+                "MultiplicativeCoprimeReward: only %d distinct rule targets "
+                "for n_rules=%d; some rules collide (selector partition "
+                "remains valid; mode-set is reduced).",
+                len(seen),
+                self.n_rules,
+            )
+
+    def _selector(self, x_active: torch.Tensor) -> torch.Tensor:
+        """Map state's active-dim values to a rule index in [0, n_rules).
+
+        Selector is sum_i x_i mod n_rules (over active dims, shifted values).
+        Returns shape (...,) long tensor.
+        """
+        return x_active.sum(dim=-1) % self.n_rules
+
     def _factor_exponents_up_to_cap(self, v: torch.Tensor, cap: int):
         """Trial-divide each element by allowed primes, returning residue and exponents.
 
@@ -1859,7 +2457,11 @@ class MultiplicativeCoprimeReward(GridReward):
         # After +1 shift, min value is 1 (origin maps to all-ones).
         # All values are >= 1 and always valid for prime factorization.
 
+        rule_idx = self._selector(x)  # shape: x.shape[:-1]
+        rule_target_exps = self._rule_target_exps.to(x.device)  # (n_rules, n_primes)
+
         valid_up_to_t = torch.ones(x.shape[:-1], device=x.device, dtype=torch.bool)
+        T_top = len(self.tier_weights) - 1
         for t, w in enumerate(self.tier_weights):
             cap = self.exponent_caps[t]
             # Flatten all active-dim values for batch factorization, then reshape.
@@ -1880,6 +2482,18 @@ class MultiplicativeCoprimeReward(GridReward):
             lcm_target = self.target_lcms[t]
             if lcm_target is not None:
                 lcm_ok = self._lcm_ok(exps, lcm_target)
+
+            # Top-tier per-rule LCM head (active when n_rules > 1, or n_rules=1
+            # with a non-None rule_targets[0]).
+            if t == T_top:
+                target_per_state = rule_target_exps[rule_idx]  # (..., n_primes)
+                # Sentinel -1 means "no LCM constraint for this rule".
+                no_target = (target_per_state == -1).all(dim=-1)
+                max_exp = exps.max(dim=-1).values  # (n_primes, ...)
+                max_exp_perm = torch.movedim(max_exp, 0, -1)  # (..., n_primes)
+                head_match = (max_exp_perm == target_per_state).all(dim=-1)
+                head_lcm_ok = no_target | head_match
+                lcm_ok = lcm_ok & head_lcm_ok
 
             tier_ok = support_ok & pairs_ok & lcm_ok
             valid_up_to_t = valid_up_to_t & tier_ok
@@ -1914,20 +2528,39 @@ class ConditionalMultiScaleReward(GridReward):
     for predicting fine-scale constraints.
 
     Per-dimension constraint at tier t (0-indexed):
-        (d_{L-1-t}(i) + sigma_t(i)) mod B < f
+        (d_{L-1-t}(i) + sigma_t(i; r)) mod B < f
 
-    where sigma_t(i) = sum_{k=0}^{t-1} a_{t,k} * d_{L-1-k}(i) mod B is a
-    linear function of coarser-scale digits with seed-derived coefficients.
+    where sigma_t(i; r) = sum_{k=0}^{t-1} a_{t,k}^{(r)} * d_{L-1-k}(i) mod B is a
+    linear function of coarser-scale digits with seed-derived coefficients,
+    parameterized by the rule index r. Tier 0 has no shift (sigma_0 = 0) and
+    is shared across all rules — it forms the trunk.
 
-    Optional cross-dimensional constraint at tier t:
+    K-rule structure (n_rules >= 1):
+        - Tier 0 is the shared trunk: constrains the most-significant digit per
+          active dim via filter [0, f). Same across all rules.
+        - The selector projects each state to a rule index r ∈ [0, n_rules)
+          deterministically: r(s) = packed_MSD(s) mod n_rules where
+          packed_MSD = sum_i d_{L-1, i} * base^i across active dims.
+        - Tiers >= 1 use rule-specific shift coefficients derived from
+          (head_seed, r), so each rule has a different head.
+
+        At n_rules=1, the selector always returns 0 and there is one head, with
+        coefficients derived from `seed` — bit-exact reproduction of the
+        single-rule reward.
+
+    Optional cross-dimensional constraint at tier t (applies to all rules):
         sum_i d_{L-1-t}(i) ≡ 0  (mod m_t)
 
-    Reward form (cumulative — tier t requires all tiers 0..t):
+    Reward form (cumulative — tier t requires all tiers 0..t under the rule):
         R(s) = R0 + sum_t tier_weights[t] * 1[s satisfies tiers 0..t]
 
-    Mode count (exact closed form):
-        Without cross-dim:  modes_T = (prod_{t=1}^T f_t)^d * B^{(L-T)*d}
-        With cross-dim:     modes_T = (prod_t f_t)^d * B^{(L-T)*d} / prod_t m_t
+    Mode count (closed form, total across all rules):
+        Without cross-dim:  modes_T = (f^T)^d * B^{(L-T)*d}
+        With cross-dim:     modes_T = (f^T)^d * B^{(L-T)*d} / prod_t m_t
+
+    The total mode count is INVARIANT in n_rules: rules partition the canonical
+    mode set. When n_rules divides f^d_active, the partition is uniform and
+    modes_per_rule = total / n_rules.
 
     Partition function (analytic, no enumeration):
         Z = R0 * H^d + sum_t w_t * modes_t
@@ -1939,6 +2572,11 @@ class ConditionalMultiScaleReward(GridReward):
         - filter_width: int, number of passing digit values per tier (default B//2).
           Constant across tiers to avoid mode collapse at deep tiers.
         - seed: int, PRNG seed for generating shift coefficients (default 42).
+        - n_rules: int, number of rules K (default 1). Selector partitions
+          tier-0-passing states into K buckets; uniform partition requires
+          K | f^d_active.
+        - head_seed: int, PRNG seed for per-rule head shift coefficients
+          (default: same as seed; ensures n_rules=1 reproduces single-rule).
         - cross_dim_mods: Optional[list[int|None]], per-tier modular cross-dim
           constraint. m_t must divide filter_width for exact mode counts.
           Default: no cross-dim constraints.
@@ -1955,6 +2593,9 @@ class ConditionalMultiScaleReward(GridReward):
           whose form depends on what was learned at prior tiers. Coarse-to-fine
           ordering creates distance-correlated difficulty.
     """
+
+    # Stride between per-rule RNG seeds; large prime to decorrelate rules.
+    _RULE_SEED_STRIDE: int = 1_000_003
 
     def __init__(self, height: int, ndim: int, **kwargs):
         super().__init__(height, ndim, **kwargs)
@@ -1990,21 +2631,65 @@ class ConditionalMultiScaleReward(GridReward):
 
         self.seed: int = int(kwargs.get("seed", 42))
 
-        # Generate shift coefficients from seed.
-        # Coarse-to-fine ordering: tier t constrains digit (L-1-t).
-        # shift_coeffs[t] has t entries: a_{t,k} for k=0..t-1, where each
-        # coefficient references digit (L-1-k) — a coarser digit already
-        # constrained by a prior tier.
-        rng = torch.Generator().manual_seed(self.seed)
-        self.shift_coeffs: list[list[int]] = []
-        for t in range(len(self.tier_weights)):
-            if t == 0:
-                self.shift_coeffs.append([])  # tier 0 has no prior digits
-            else:
-                coeffs = torch.randint(0, self.base, (t,), generator=rng).tolist()
-                self.shift_coeffs.append(coeffs)
+        # Per-tier constant filter shift. Default None → 0 at every tier
+        # (current behavior: tier-t passing window starts at digit=0). Setting
+        # filter_shift[t]=c moves tier t's passing window to start at digit
+        # (-c) mod B — i.e., the blind strip cyclically rotates. Useful for
+        # spreading mode coverage across the full axis instead of clumping
+        # in the lower f/B fraction.
+        filter_shift = kwargs.get("filter_shift", None)
+        if filter_shift is None:
+            filter_shift = [0] * len(self.tier_weights)
+        assert len(filter_shift) == len(self.tier_weights), (
+            f"filter_shift length {len(filter_shift)} != n_tiers {len(self.tier_weights)}"
+        )
+        self.filter_shift: list[int] = [int(s) % self.base for s in filter_shift]
 
-        # Cross-dimensional modular constraints (optional)
+        active_dims = kwargs.get("active_dims", None)
+        if active_dims is None:
+            active_dims = list(range(ndim))
+        self.active_dims: list[int] = list(map(int, active_dims))
+
+        # K-rule structure. n_rules=1 reproduces the original single-rule reward
+        # bit-exactly: rule 0's RNG is seeded by head_seed (defaulting to seed),
+        # which matches the historical generator state.
+        self.n_rules: int = int(kwargs.get("n_rules", 1))
+        assert self.n_rules >= 1, f"n_rules must be >= 1, got {self.n_rules}"
+        head_seed = kwargs.get("head_seed", self.seed)
+        if head_seed is None:
+            raise ValueError("head_seed=None is not allowed; pass an int or omit.")
+        self.head_seed: int = int(head_seed)
+
+        # Generate per-rule shift coefficients.
+        # shift_coeffs_per_rule[r][t] has length t (empty list for t=0).
+        # Coefficient a_{t,k}^{(r)} references digit (L-1-k) — a coarser digit
+        # already constrained by a prior tier — for rule r.
+        self.shift_coeffs_per_rule: list[list[list[int]]] = []
+        for r in range(self.n_rules):
+            rule_seed = (
+                self.head_seed if r == 0 else self.head_seed + r * self._RULE_SEED_STRIDE
+            )
+            rng = torch.Generator().manual_seed(rule_seed)
+            rule_shifts: list[list[int]] = []
+            for t in range(len(self.tier_weights)):
+                if t == 0:
+                    rule_shifts.append([])
+                else:
+                    coeffs = torch.randint(0, self.base, (t,), generator=rng).tolist()
+                    rule_shifts.append(coeffs)
+            self.shift_coeffs_per_rule.append(rule_shifts)
+
+        # Pre-pack rule shift coefficients as a (n_rules, n_tiers, n_tiers) tensor
+        # for fast per-state gather in __call__. Padded with zeros where j >= t.
+        n_tiers = len(self.tier_weights)
+        shift_tensor = torch.zeros(self.n_rules, n_tiers, n_tiers, dtype=torch.long)
+        for r in range(self.n_rules):
+            for t in range(n_tiers):
+                for j_idx, c in enumerate(self.shift_coeffs_per_rule[r][t]):
+                    shift_tensor[r, t, j_idx] = c
+        self._shift_coeffs_tensor: torch.Tensor = shift_tensor
+
+        # Cross-dimensional modular constraints (optional, applied to all rules)
         cross_dim_mods = kwargs.get("cross_dim_mods", None)
         if cross_dim_mods is None:
             cross_dim_mods = [None] * len(self.tier_weights)
@@ -2020,10 +2705,93 @@ class ConditionalMultiScaleReward(GridReward):
                 )
             self.cross_dim_mods.append(m)
 
-        active_dims = kwargs.get("active_dims", None)
-        if active_dims is None:
-            active_dims = list(range(ndim))
-        self.active_dims: list[int] = list(map(int, active_dims))
+        # Construction-time check for K-rule structure: every rule must be
+        # represented by at least one trunk-passing pattern. Enumerates the
+        # f^d_active tier-0-passing patterns (small: e.g. 64 at f=2, d=6).
+        self._uniform_partition: bool = True
+        if self.n_rules > 1:
+            self._validate_rule_coverage()
+
+    def _validate_rule_coverage(self) -> None:
+        """Ensure every rule index is hit by at least one trunk-passing state.
+
+        Trunk = tier 0 = each active dim's shifted MSD in [0, filter_width)
+        AND (if cross_dim_mods[0] is set) MSD-sum mod m_0 == 0. The selector
+        packs MSDs as base-f and mods by n_rules.
+
+        Implementation uses cyclic-uniformity: trunk-passing MSD patterns map
+        bijectively to integers [0, f^d_active) via the base-f packing, so
+        `pat mod n_rules` distributes uniformly when `n_rules | n_surv`. The
+        cross-dim filter at tier 0 thins this set further; for non-trivial
+        cross_mod_0 we sample to verify coverage. (Old enumeration over
+        f^d_active patterns was intractable at d_active > ~10.)
+
+        Sets `_uniform_partition` based on whether n_rules divides the
+        trunk-passing count evenly.
+        """
+        d_active = len(self.active_dims)
+        f = self.filter_width
+        cross_mod_0 = self.cross_dim_mods[0]
+
+        n_patterns = f**d_active  # tier-0-filter-passing patterns
+        if cross_mod_0 is None:
+            n_surv = n_patterns
+            uniform_after_cross = True
+        else:
+            # Each cross_mod_0 is a divisor of f, and the sum-mod-m constraint
+            # picks 1/m of the patterns symmetrically. Hence n_surv = n_patterns / m.
+            assert n_patterns % cross_mod_0 == 0, (
+                f"f^d_active={n_patterns} not divisible by cross_dim_mods[0]={cross_mod_0}"
+            )
+            n_surv = n_patterns // cross_mod_0
+            uniform_after_cross = True
+
+        if self.n_rules > n_surv:
+            raise ValueError(
+                f"n_rules={self.n_rules} exceeds trunk-passing pattern count "
+                f"{n_surv} (f^d_active={f}^{d_active}={n_patterns}, "
+                f"cross_dim_mods[0]={cross_mod_0}); some rules cannot be reached."
+            )
+
+        # With cyclic uniformity (no cross_dim_mods[0]), or symmetric cross-dim
+        # reduction by a divisor of f, the bucket distribution is determined
+        # by n_surv mod n_rules. All buckets non-empty iff n_surv >= n_rules,
+        # which we already verified. Uniform iff n_surv % n_rules == 0.
+        # If cross_mod_0 happens to interact pathologically with the selector,
+        # we'd miss it here — fall back to enumeration only at small d_active.
+        ENUM_THRESHOLD = 12
+        if d_active <= ENUM_THRESHOLD:
+            bucket_counts = [0] * self.n_rules
+            survivors_iter = range(n_patterns) if cross_mod_0 is None else (
+                pat for pat in range(n_patterns)
+                if sum((pat // (f**i)) % f for i in range(d_active)) % cross_mod_0 == 0
+            )
+            for pat in survivors_iter:
+                bucket_counts[pat % self.n_rules] += 1
+            empty = [k for k, c in enumerate(bucket_counts) if c == 0]
+            if empty:
+                raise ValueError(
+                    f"K-rule selector leaves rules {empty} with no trunk-passing "
+                    f"states (n_rules={self.n_rules}, trunk-passing patterns="
+                    f"{n_surv}). Loosen cross_dim_mods[0] or reduce n_rules."
+                )
+            self._uniform_partition: bool = (
+                n_surv % self.n_rules == 0 and len(set(bucket_counts)) == 1
+            )
+        else:
+            # Above threshold: rely on cyclic-uniformity. n_rules ≤ n_surv
+            # already verified; uniform partition iff n_rules divides n_surv.
+            self._uniform_partition = (n_surv % self.n_rules == 0)
+
+        if not self._uniform_partition:
+            logger.warning(
+                "ConditionalMultiScaleReward: n_rules=%d does not yield a "
+                "uniform partition over %d trunk-passing patterns. Rule mode "
+                "counts will be imbalanced; analytic_mode_count(per_rule=True) "
+                "is no longer well-defined and will raise.",
+                self.n_rules,
+                n_surv,
+            )
 
     def _extract_digits(self, x: torch.Tensor, num_levels: int) -> list[torch.Tensor]:
         """Extract base-B digits from x.
@@ -2042,6 +2810,23 @@ class ConditionalMultiScaleReward(GridReward):
             digits.append(remaining % self.base)
             remaining = remaining // self.base
         return digits
+
+    def _selector(self, msd_digits: torch.Tensor) -> torch.Tensor:
+        """Map state MSDs (..., d_active) -> rule index in [0, n_rules).
+
+        Applies the same shift used by tier 0's filter (sigma_0 = 0 +
+        filter_shift[0]) before packing as base-f. For trunk-passing states
+        the shifted MSD is in [0, f) so the packing is bijective on the
+        trunk-passing set; non-trunk-passing states still get a rule index
+        but cannot become modes (their tier-0 check fails).
+        """
+        d_active = msd_digits.shape[-1]
+        f = self.filter_width
+        fs0 = self.filter_shift[0]
+        shifted = (msd_digits + fs0) % self.base
+        powers = f ** torch.arange(d_active, device=msd_digits.device, dtype=torch.long)
+        packed = ((shifted % f) * powers).sum(dim=-1)
+        return packed % self.n_rules
 
     def __call__(self, states_tensor: torch.Tensor) -> torch.Tensor:
         R = torch.zeros(
@@ -2062,20 +2847,29 @@ class ConditionalMultiScaleReward(GridReward):
         L = self.num_levels
         digits = self._extract_digits(x, L)
 
+        # Selector: rule index per state, derived from MSDs.
+        rule_idx = self._selector(digits[L - 1])  # shape: x.shape[:-1]
+        shift_coeffs_t = self._shift_coeffs_tensor.to(x.device)  # (K, n_tiers, n_tiers)
+
         valid_up_to_t = torch.ones(x.shape[:-1], device=x.device, dtype=torch.bool)
         for t, w in enumerate(self.tier_weights):
             # Coarse-to-fine: tier t constrains digit (L-1-t).
             target_digit = digits[L - 1 - t]
 
-            # Shift uses coarser digits already constrained: digits[L-1-k]
-            # for k=0..t-1.
+            # Tier 0 is the shared trunk (no state-dependent shift). Tiers ≥ 1
+            # use rule-specific state-dependent shifts gathered by rule_idx.
+            # An optional per-tier constant filter_shift[t] is added on top.
             if t == 0:
-                shift = torch.zeros_like(x)
+                shift = torch.full_like(x, self.filter_shift[t])
             else:
-                shift = torch.zeros_like(x)
-                for k, a_tk in enumerate(self.shift_coeffs[t]):
-                    if a_tk != 0:
-                        shift = shift + int(a_tk) * digits[L - 1 - k]
+                # tier_coeffs_all: (K, t) — rule k's coefficients a_{t,0..t-1}.
+                tier_coeffs_all = shift_coeffs_t[:, t, :t]
+                # per_state_coeffs: (..., t) — broadcast-gather over rule_idx.
+                per_state_coeffs = tier_coeffs_all[rule_idx]
+                shift = torch.full_like(x, self.filter_shift[t])
+                for k_idx in range(t):
+                    a = per_state_coeffs[..., k_idx].unsqueeze(-1)  # (..., 1)
+                    shift = shift + a * digits[L - 1 - k_idx]
                 shift = shift % self.base
 
             # Filter: shifted digit must be in [0, filter_width).
@@ -2133,15 +2927,24 @@ class ConditionalMultiScaleReward(GridReward):
         t = self.mode_tier(target_sparsity)
         return self.R0 + sum(self.tier_weights[:t])
 
-    def analytic_mode_count(self, tier: int | None = None) -> int:
+    def analytic_mode_count(
+        self, tier: int | None = None, per_rule: bool = False
+    ) -> int:
         """Compute exact mode count for a given tier (1-indexed) or all tiers.
+
+        Total mode count is invariant in `n_rules` — rules partition the
+        canonical mode set rather than multiplying it.
 
         Args:
             tier: 1-indexed tier number. If None, returns count for the
                   highest tier (most constrained).
+            per_rule: If True, returns the per-rule count (total // n_rules).
+                Requires uniform partition (n_rules divides the trunk-passing
+                pattern count); raises ValueError otherwise.
 
         Returns:
-            Number of states satisfying all constraints up to the given tier.
+            Number of states satisfying all constraints up to the given tier
+            (over all rules combined if per_rule=False, per rule otherwise).
         """
         if tier is None:
             tier = len(self.tier_weights)
@@ -2154,8 +2957,12 @@ class ConditionalMultiScaleReward(GridReward):
         f = self.filter_width
 
         # Per-dim: (f)^T valid constrained digit combos × B^(L-T) free digits
+        # extended over inactive dims (which are unconstrained, so B^L each).
         choices_per_coord = (f**T) * (B ** (L - T))
         modes = choices_per_coord**d
+        # Inactive dims contribute B^L = self.height each.
+        n_inactive = self.ndim - d
+        modes *= self.height**n_inactive
 
         # Cross-dim modular constraints divide out uniformly.
         for t in range(T):
@@ -2163,15 +2970,22 @@ class ConditionalMultiScaleReward(GridReward):
             if cross_mod is not None:
                 modes //= cross_mod
 
+        if per_rule:
+            if not self._uniform_partition:
+                raise ValueError(
+                    f"analytic_mode_count(per_rule=True) requires a uniform "
+                    f"K-partition; n_rules={self.n_rules} does not partition "
+                    f"the trunk-passing set evenly."
+                )
+            return modes // self.n_rules
         return modes
 
     def analytic_log_partition(self) -> float:
         """Compute log(Z) analytically.
 
-        Z = R0 * H^d + sum_t w_t * modes_t
+        Z = R0 * H^ndim + sum_t w_t * modes_t
         """
-        d = len(self.active_dims)
-        Z = self.R0 * (self.height**d)
+        Z = self.R0 * (self.height**self.ndim)
         for t in range(len(self.tier_weights)):
             Z += self.tier_weights[t] * self.analytic_mode_count(tier=t + 1)
         return log(Z) if Z > 0 else float("-inf")
@@ -2342,6 +3156,43 @@ def get_bitwise_xor_presets(ndim: int, height: int) -> dict:
         "challenging": _make_preset("challenging", 10, [1, 2, 4]),
         "impossible": _make_preset("impossible", 12, [2, 4, 6]),
     }
+
+    # K-rule trunk+heads presets (designed for ndim=10, H=16). Density ~9.5e-7
+    # is invariant across K — selector partitions trunk-and-head-passing states.
+    # Trunk: M=10 (all dims), checks_per_tier=[1,1,2] -> 4 cumulative trunk
+    # checks per bit-plane * 4 bit-planes = 16 trunk checks total.
+    # Head: 1 check per bit-plane * 4 bit-planes = 4 head rows per rule.
+    # Selector: ceil(log2(K)) bits over the full M*B=40 bit space.
+    # Mode count: 2^(40 - 16 - 4) = 2^20 = ~1M total, invariant in K.
+    if ndim >= 10:
+        k_trunk = _make_preset("Ktrunk", 10, [1, 1, 2])
+        for n_rules in (1, 16, 64):
+            presets[f"K{n_rules}"] = dict(
+                k_trunk,
+                n_rules=n_rules,
+                head_seed=2025,
+                head_weight=1000.0,
+                head_check_count=1,
+                head_bit_range=(0, max_bit),
+            )
+
+        # "Matched" K-presets: production-grade matched-density (~1e-7) with
+        # K=64 specialization at ndim=10, h=16. Trunk same as standard K-presets
+        # (16 rows); head extended to 2 checks across 3 bit-planes (r_head=6)
+        # for richer per-rule heads at slightly tighter density (2.4e-7 vs the
+        # standard preset's 9.5e-7). T_max=150, parity-symmetric coverage.
+        # Total modes: 2^(40 - 16 - 6) = 2^18 = 262K, density 2.4e-7.
+        k_trunk_matched = _make_preset("Ktrunk_matched", 10, [1, 1, 2])
+        for n_rules in (1, 16, 64):
+            presets[f"K{n_rules}_matched"] = dict(
+                k_trunk_matched,
+                n_rules=n_rules,
+                head_seed=2025,
+                head_weight=1000.0,
+                head_check_count=2,
+                head_bit_range=(0, 2),
+            )
+
     return presets
 
 
@@ -2429,11 +3280,66 @@ def get_multiplicative_coprime_presets(ndim: int, height: int) -> dict:
             target_lcms=[None, None, None, None, "auto"],
         ),
     }
+
+    # K-rule trunk+heads presets (designed for ndim=6, H=64). Trunk = tiers 0..2
+    # (smooth-number + caps + coprime pairs). Head = tier 3, with per-rule LCM
+    # target enumerated from cap-tuples. Primes={2,3,5,7} all representable at
+    # cap=2 in h=64; cap_p ∈ {1, 2} gives 2^4 = 16 distinct LCMs.
+    #
+    # K=64 is not supported at h=64 because it would require either (a) a
+    # 6-prime universe where 11 and 13 force auto-cap to 1, collapsing the
+    # enum, or (b) cap=3 which isn't representable for primes 5 and 7 at h=64.
+    # K=64 coprime is left as a TODO; users can pick h=256 with 6 primes.
+    # K=1 draws rule 0 from the same enum so density matches K=16.
+    if ndim >= 6:
+        k_trunk = dict(
+            R0=0.0,
+            tier_weights=[1.0, 10.0, 100.0, 1000.0],
+            primes=[2, 3, 5, 7],
+            exponent_caps=[2, 2, 2, 2],
+            active_dims=_first_k_dims(6, ndim),
+            coprime_pairs=chain_pairs(6),
+            coprime_start_tier=2,
+            target_lcms=[None, None, None, None],
+        )
+        for n_rules in (1, 16):
+            presets[f"K{n_rules}"] = dict(
+                k_trunk,
+                n_rules=n_rules,
+                head_seed=2025,
+            )
+
+    # "Matched" K-presets: production-grade matched-density (~1e-7) with
+    # K=64 specialization at ndim=10, h=64. Selector-only K-rule because the
+    # cap-tuple LCM enum tops out at K=16 with 4 primes; K=64 needs h>=169 for
+    # 6-prime caps, which makes T_max prohibitive. The trunk holds the LCM=auto
+    # constraint (44100), and the selector partitions the same canonical mode
+    # set into 64 buckets — rules differ in spatial assignment, not per-rule
+    # head LCM. T_max=630, smooth-set spans 1–64 per dim (no origin clumping).
+    if ndim >= 10:
+        k_trunk_matched = dict(
+            R0=0.0,
+            tier_weights=[1.0, 10.0, 100.0, 1000.0],
+            primes=[2, 3, 5, 7],
+            exponent_caps=[2, 2, 2, 2],
+            active_dims=_first_k_dims(10, ndim),
+            coprime_pairs=chain_pairs(10),
+            coprime_start_tier=2,
+            target_lcms=[None, None, None, "auto"],
+        )
+        for n_rules in (1, 16, 64):
+            presets[f"K{n_rules}_matched"] = dict(
+                k_trunk_matched,
+                n_rules=n_rules,
+                head_seed=2025,
+                rule_targets=[None] * n_rules,
+            )
+
     return presets
 
 
 def get_conditional_multiscale_presets(ndim: int, height: int) -> dict:
-    """Return five difficulty presets for ConditionalMultiScaleReward.
+    """Return difficulty presets for ConditionalMultiScaleReward.
 
     All presets use base=4 (requiring H to be a power of 4). The number of
     available digit levels is L = log_4(H). Difficulty is controlled by:
@@ -2442,7 +3348,7 @@ def get_conditional_multiscale_presets(ndim: int, height: int) -> dict:
       - Cross-dim modular constraints (further sparsification)
 
     Mode counts are computed via:
-        modes_T = (f^T * 4^{L-T})^d / prod_t m_t
+        modes_T = (f^T * 4^{L-T})^d * H^(ndim-d) / prod_t m_t
 
     with f = filter_width = 2 (i.e. B//2), so each tier halves modes per coord.
 
@@ -2451,12 +3357,19 @@ def get_conditional_multiscale_presets(ndim: int, height: int) -> dict:
     pass the filter. Deeper tiers constrain progressively finer digits,
     creating distance-correlated difficulty.
 
-    Presets (assuming H=256, i.e. L=4 digit levels):
+    Two preset families:
+
+    Difficulty presets (single-rule legacy, assuming H=256, i.e. L=4):
       - easy:        2 tiers, 3 active dims -> ~2M modes at tier 2
       - medium:      3 tiers, 4 active dims -> ~1M modes at tier 3
       - hard:        3 tiers, 6 active dims, cross-dim -> ~260K modes at tier 3
       - challenging: 4 tiers, 8 active dims, cross-dim -> ~65K modes at tier 4
       - impossible:  4 tiers, 12 active dims, cross-dim -> ~4K modes at tier 4
+
+    K-rule trunk+heads presets (sparsity matched, K rules sharing tier-0 trunk):
+      - K1, K16, K64: 3 tiers, 6 active dims, cross_dim_mods=[2,2,2].
+        Total modes invariant in K (~32K total at H=64, density ~5e-7); rules
+        partition the canonical mode set. Designed for ndim=6, H=64.
 
     If height provides fewer digit levels than a preset requires, the preset's
     tier_weights and cross_dim_mods are auto-truncated with a warning.
@@ -2544,6 +3457,50 @@ def get_conditional_multiscale_presets(ndim: int, height: int) -> dict:
             )
         ),
     }
+
+    # K-rule trunk+heads presets (designed for ndim=6, H=64).
+    # Density ~9.5e-7 (~65K modes) is invariant across K — rules partition the
+    # canonical mode set. cross_dim_mods[0] is None: a tier-0 cross-dim filter
+    # would shrink the trunk-passing set below n_rules and leave rules empty.
+    # head_seed is shared across K presets so K=1's rule 0 == K=16's rule 0
+    # == K=64's rule 0 by construction (useful for cross-K diagnostics).
+    k_rule_template = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0],
+        base=base,
+        filter_width=2,
+        seed=42,
+        head_seed=2025,
+        active_dims=_first_k_dims(6, ndim),
+        cross_dim_mods=[None, 2, 2],
+    )
+    for n_rules in (1, 16, 64):
+        presets[f"K{n_rules}"] = _cap_tiers(dict(k_rule_template, n_rules=n_rules))
+
+    # "Matched" K-presets: production-grade matched-density (~1e-7) with K=64
+    # specialization at ndim=24, h=16 (base=4, L=2, f=3). Trades dim count for
+    # trajectory length: T_max=360 (vs 882 at ndim=14, h=64). 75% per-axis
+    # coverage via filter_width=3 over base=4 — 3-of-4 top digits pass tier 0,
+    # so each axis has only a 25% blind strip (cyclic via filter_shift if you
+    # want it elsewhere). cross_dim_mods=[3,3] tightens density without
+    # collapsing the partition. K_native = 3^24 ≈ 282B; K=64 is non-uniform
+    # (3^23 not divisible by 64) but every rule is reachable.
+    if ndim >= 24:
+        k_rule_matched_template = dict(
+            R0=0.0,
+            tier_weights=[1.0, 10.0],
+            base=base,
+            filter_width=3,
+            seed=42,
+            head_seed=2025,
+            active_dims=_first_k_dims(24, ndim),
+            cross_dim_mods=[3, 3],
+        )
+        for n_rules in (1, 16, 64):
+            presets[f"K{n_rules}_matched"] = _cap_tiers(
+                dict(k_rule_matched_template, n_rules=n_rules)
+            )
+
     return presets
 
 

--- a/src/gfn/gym/hypergrid.py
+++ b/src/gfn/gym/hypergrid.py
@@ -3524,16 +3524,18 @@ def get_bitwise_xor_presets(ndim: int, height: int) -> dict:
         # for richer per-rule heads at slightly tighter density (2.4e-7 vs the
         # standard preset's 9.5e-7). T_max=150, parity-symmetric coverage.
         # Total modes: 2^(40 - 16 - 6) = 2^18 = 262K, density 2.4e-7.
-        k_trunk_matched = _make_preset("Ktrunk_matched", 10, [1, 1, 2])
-        for n_rules in (1, 16, 64):
-            presets[f"K{n_rules}_matched"] = dict(
-                k_trunk_matched,
-                n_rules=n_rules,
-                head_seed=2025,
-                head_weight=1000.0,
-                head_check_count=2,
-                head_bit_range=(0, 2),
-            )
+        # Requires height >= 8 (B >= 3) so head_bit_range=(0, 2) is valid.
+        if height >= 8:
+            k_trunk_matched = _make_preset("Ktrunk_matched", 10, [1, 1, 2])
+            for n_rules in (1, 16, 64):
+                presets[f"K{n_rules}_matched"] = dict(
+                    k_trunk_matched,
+                    n_rules=n_rules,
+                    head_seed=2025,
+                    head_weight=1000.0,
+                    head_check_count=2,
+                    head_bit_range=(0, 2),
+                )
 
     return presets
 

--- a/src/gfn/gym/hypergrid.py
+++ b/src/gfn/gym/hypergrid.py
@@ -891,7 +891,7 @@ class HyperGrid(DiscreteEnv):
             return True
         return self._solve_gf2_has_solution(full_A, full_c)
 
-    def _exists_multiplicative_coprime(self, thr: float) -> bool:
+    def _exists_multiplicative_coprime(self, thr: float) -> bool:  # noqa: C901
         """Number-theoretic constructive check for ``MultiplicativeCoprimeReward``.
 
         For each rule, factors the rule's target LCM over allowed primes,
@@ -1678,7 +1678,7 @@ class BitwiseXORReward(GridReward):
 
     _RULE_SEED_STRIDE: int = 1_000_003
 
-    def __init__(self, height: int, ndim: int, **kwargs):
+    def __init__(self, height: int, ndim: int, **kwargs):  # noqa: C901
         super().__init__(height, ndim, **kwargs)
         self.R0: float = float(kwargs.get("R0", 0.0))
         tier_weights = kwargs.get("tier_weights", [1.0, 10.0, 100.0])
@@ -1866,9 +1866,7 @@ class BitwiseXORReward(GridReward):
                 if self._full_A.numel() == 0:
                     combined_rank = _gf2_rank(S_long)
                 else:
-                    combined_rank = _gf2_rank(
-                        torch.cat([self._full_A, S_long], dim=0)
-                    )
+                    combined_rank = _gf2_rank(torch.cat([self._full_A, S_long], dim=0))
                 if combined_rank == trunk_rank_for_indep + self.k_select:
                     break
             else:
@@ -1890,9 +1888,7 @@ class BitwiseXORReward(GridReward):
         lo_h, hi_h = self.head_bit_range
         n_head_bits = max(0, hi_h - lo_h + 1)
         r_head_total = self.head_check_count * n_head_bits
-        self._head_c_per_rule = torch.zeros(
-            self.n_rules, r_head_total, dtype=torch.long
-        )
+        self._head_c_per_rule = torch.zeros(self.n_rules, r_head_total, dtype=torch.long)
         if self.head_check_count > 0 and n_head_bits > 0:
             A_r, _ = _gf2_random_fullrank(
                 self.head_check_count, M, self.head_seed + self._RULE_SEED_STRIDE
@@ -1901,9 +1897,9 @@ class BitwiseXORReward(GridReward):
             row = 0
             for bb in range(lo_h, hi_h + 1):
                 for cd in range(M):
-                    self._head_A[row : row + self.head_check_count, cd * B + bb] = (
-                        A_r[:, cd].long()
-                    )
+                    self._head_A[row : row + self.head_check_count, cd * B + bb] = A_r[
+                        :, cd
+                    ].long()
                 row += self.head_check_count
             # Per-rule head_c via witness construction.
             for rule in range(self.n_rules):
@@ -1925,9 +1921,9 @@ class BitwiseXORReward(GridReward):
 
         # Stack head_A into per-rule shape (n_rules, r_head_total, M*B) for
         # batched gather in __call__. All rules share the same A matrix.
-        self._head_A_per_rule = self._head_A.unsqueeze(0).expand(
-            self.n_rules, -1, -1
-        ).contiguous()
+        self._head_A_per_rule = (
+            self._head_A.unsqueeze(0).expand(self.n_rules, -1, -1).contiguous()
+        )
 
         # Powers of 2 for packing selector bits to rule_idx.
         self._select_powers = (
@@ -1997,8 +1993,6 @@ class BitwiseXORReward(GridReward):
         unconstrained dims.
         """
         M = len(self.dims_constrained)
-        B = self._B
-        n_vars = M * B
         unconstrained = self.height ** (self.ndim - M)
         per_rule_counts = self._per_rule_mode_counts()
         total = sum(per_rule_counts) * unconstrained
@@ -2037,9 +2031,7 @@ class BitwiseXORReward(GridReward):
                 [self._full_A, self._selector_matrix, self._head_A_per_rule[r]],
                 dim=0,
             )
-            c = torch.cat(
-                [self._full_c, sel_target, self._head_c_per_rule[r]], dim=0
-            )
+            c = torch.cat([self._full_c, sel_target, self._head_c_per_rule[r]], dim=0)
             if A.numel() == 0:
                 counts.append(2**n_vars)
                 continue
@@ -2149,9 +2141,7 @@ class BitwiseXORReward(GridReward):
             head_c = self._head_c_per_rule.to(dev)
             A_per_state = head_A[rule_idx]
             c_per_state = head_c[rule_idx]
-            head_prod = (
-                torch.einsum("...rj,...j->...r", A_per_state, flat_bits) & 1
-            )
+            head_prod = torch.einsum("...rj,...j->...r", A_per_state, flat_bits) & 1
             head_ok = (head_prod == c_per_state).all(-1)
 
             R = R + (tier_ok & head_ok).to(R.dtype) * self.head_weight
@@ -2222,7 +2212,7 @@ class MultiplicativeCoprimeReward(GridReward):
           each tier requires understanding the prior tier's structure.
     """
 
-    def __init__(self, height: int, ndim: int, **kwargs):
+    def __init__(self, height: int, ndim: int, **kwargs):  # noqa: C901
         super().__init__(height, ndim, **kwargs)
         self.R0: float = float(kwargs.get("R0", 0.0))
         tier_weights = kwargs.get("tier_weights", [1.0, 10.0, 100.0])
@@ -2308,20 +2298,14 @@ class MultiplicativeCoprimeReward(GridReward):
         assert self.n_rules >= 1, f"n_rules must be >= 1, got {self.n_rules}"
         head_seed_provided = kwargs.get("head_seed", None) is not None
         if not head_seed_provided and self.n_rules > 1:
-            raise ValueError(
-                "head_seed must be provided when n_rules > 1; got None."
-            )
-        self.head_seed: int = (
-            int(kwargs["head_seed"]) if head_seed_provided else 0
-        )
+            raise ValueError("head_seed must be provided when n_rules > 1; got None.")
+        self.head_seed: int = int(kwargs["head_seed"]) if head_seed_provided else 0
 
         rule_targets = kwargs.get("rule_targets", None)
         rule_targets_inherited_from_trunk = False
         if rule_targets is None:
             if head_seed_provided:
-                rule_targets = self._generate_rule_targets(
-                    self.n_rules, self.head_seed
-                )
+                rule_targets = self._generate_rule_targets(self.n_rules, self.head_seed)
             else:
                 # Legacy K=1 backward-compat: head's single LCM mirrors the
                 # trunk's top-tier LCM. Mark as inherited so we don't later
@@ -2329,9 +2313,9 @@ class MultiplicativeCoprimeReward(GridReward):
                 # preserving it keeps pre-refactor reward output bit-exact).
                 rule_targets = [self.target_lcms[-1]]
                 rule_targets_inherited_from_trunk = True
-        assert len(rule_targets) == self.n_rules, (
-            f"rule_targets has {len(rule_targets)} entries; expected n_rules={self.n_rules}"
-        )
+        assert (
+            len(rule_targets) == self.n_rules
+        ), f"rule_targets has {len(rule_targets)} entries; expected n_rules={self.n_rules}"
         self.rule_targets: list[int | None] = [
             int(t) if t is not None else None for t in rule_targets
         ]
@@ -2711,7 +2695,7 @@ class ConditionalMultiScaleReward(GridReward):
     # Stride between per-rule RNG seeds; large prime to decorrelate rules.
     _RULE_SEED_STRIDE: int = 1_000_003
 
-    def __init__(self, height: int, ndim: int, **kwargs):
+    def __init__(self, height: int, ndim: int, **kwargs):  # noqa: C901
         super().__init__(height, ndim, **kwargs)
         self.R0: float = float(kwargs.get("R0", 0.0))
 
@@ -2754,9 +2738,9 @@ class ConditionalMultiScaleReward(GridReward):
         filter_shift = kwargs.get("filter_shift", None)
         if filter_shift is None:
             filter_shift = [0] * len(self.tier_weights)
-        assert len(filter_shift) == len(self.tier_weights), (
-            f"filter_shift length {len(filter_shift)} != n_tiers {len(self.tier_weights)}"
-        )
+        assert len(filter_shift) == len(
+            self.tier_weights
+        ), f"filter_shift length {len(filter_shift)} != n_tiers {len(self.tier_weights)}"
         self.filter_shift: list[int] = [int(s) % self.base for s in filter_shift]
 
         active_dims = kwargs.get("active_dims", None)
@@ -2850,15 +2834,13 @@ class ConditionalMultiScaleReward(GridReward):
         n_patterns = f**d_active  # tier-0-filter-passing patterns
         if cross_mod_0 is None:
             n_surv = n_patterns
-            uniform_after_cross = True
         else:
             # Each cross_mod_0 is a divisor of f, and the sum-mod-m constraint
             # picks 1/m of the patterns symmetrically. Hence n_surv = n_patterns / m.
-            assert n_patterns % cross_mod_0 == 0, (
-                f"f^d_active={n_patterns} not divisible by cross_dim_mods[0]={cross_mod_0}"
-            )
+            assert (
+                n_patterns % cross_mod_0 == 0
+            ), f"f^d_active={n_patterns} not divisible by cross_dim_mods[0]={cross_mod_0}"
             n_surv = n_patterns // cross_mod_0
-            uniform_after_cross = True
 
         if self.n_rules > n_surv:
             raise ValueError(
@@ -2876,9 +2858,15 @@ class ConditionalMultiScaleReward(GridReward):
         ENUM_THRESHOLD = 12
         if d_active <= ENUM_THRESHOLD:
             bucket_counts = [0] * self.n_rules
-            survivors_iter = range(n_patterns) if cross_mod_0 is None else (
-                pat for pat in range(n_patterns)
-                if sum((pat // (f**i)) % f for i in range(d_active)) % cross_mod_0 == 0
+            survivors_iter = (
+                range(n_patterns)
+                if cross_mod_0 is None
+                else (
+                    pat
+                    for pat in range(n_patterns)
+                    if sum((pat // (f**i)) % f for i in range(d_active)) % cross_mod_0
+                    == 0
+                )
             )
             for pat in survivors_iter:
                 bucket_counts[pat % self.n_rules] += 1
@@ -2895,7 +2883,7 @@ class ConditionalMultiScaleReward(GridReward):
         else:
             # Above threshold: rely on cyclic-uniformity. n_rules ≤ n_surv
             # already verified; uniform partition iff n_rules divides n_surv.
-            self._uniform_partition = (n_surv % self.n_rules == 0)
+            self._uniform_partition = n_surv % self.n_rules == 0
 
         if not self._uniform_partition:
             logger.warning(

--- a/testing/test_hypergrid.py
+++ b/testing/test_hypergrid.py
@@ -369,3 +369,969 @@ def test_mode_counts_match_enumeration(reward_name, kwargs_fn, ndim, height):
     # Verify modes_found returns the correct canonical indices.
     found = env.modes_found(all_states)
     assert len(found) == expected
+
+
+# -------------------------
+# ConditionalMultiScaleReward — single-rule (legacy compat)
+# -------------------------
+
+
+def test_conditional_multiscale_reward_values_small():
+    # Small grid where we can hand-verify the reward.
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=2,
+        filter_width=1,
+        seed=0,
+        active_dims=[0, 1],
+    )
+    env = _make_env("conditional_multiscale", kwargs, ndim=2, height=4)
+    # Origin: all-zero digits -> all tiers pass.
+    r0 = env.reward(env.States(torch.tensor([[0, 0]], dtype=torch.long)))[0].item()
+    assert abs(r0 - (0.0 + 1.0 + 10.0)) < 1e-6
+
+
+def test_conditional_multiscale_legacy_n_rules_default_is_1():
+    # Backwards-compat: omitting n_rules must yield n_rules=1 with shift_coeffs
+    # derived from `seed`, reproducing pre-K-rule behavior bit-exactly.
+    # Use ndim=4, height=64 so the medium preset's 3 tiers are not truncated.
+    kwargs = get_reward_presets("conditional_multiscale", 4, 64)["medium"]
+    env = _make_env("conditional_multiscale", kwargs, ndim=4, height=64)
+    rf = env.reward_fn
+    assert rf.n_rules == 1
+    assert rf.head_seed == rf.seed
+    # The historical sequence with seed=42, base=4, 3 tiers:
+    # tier 0: []; tier 1: torch.randint(0,4,(1,)) -> [2]; tier 2: torch.randint(0,4,(2,)) -> [3, 0]
+    assert rf.shift_coeffs_per_rule[0] == [[], [2], [3, 0]]
+
+
+def test_conditional_multiscale_validate_modes_succeeds_legacy():
+    kwargs = get_reward_presets("conditional_multiscale", 4, 16)["medium"]
+    env = _make_env(
+        "conditional_multiscale", kwargs, ndim=4, height=16, validate_modes=True
+    )
+    assert env.n_actions == env.ndim + 1
+
+
+# -------------------------
+# ConditionalMultiScaleReward — K-rule trunk+heads
+# -------------------------
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_conditional_multiscale_K_presets_validate_modes(n_rules):
+    p = get_reward_presets("conditional_multiscale", ndim=6, height=64)[f"K{n_rules}"]
+    env = _make_env(
+        "conditional_multiscale",
+        p,
+        ndim=6,
+        height=64,
+        validate_modes=True,
+    )
+    assert env.reward_fn.n_rules == n_rules
+
+
+def test_conditional_multiscale_density_invariant_in_K():
+    """Total mode count must be invariant under n_rules (rules partition,
+    not multiply, the canonical mode set)."""
+    presets = get_reward_presets("conditional_multiscale", ndim=6, height=64)
+    counts = []
+    for n_rules in (1, 16, 64):
+        env = _make_env(
+            "conditional_multiscale",
+            presets[f"K{n_rules}"],
+            ndim=6,
+            height=64,
+            validate_modes=False,
+        )
+        counts.append(env.reward_fn.analytic_mode_count())
+    assert len(set(counts)) == 1, f"mode counts vary with K: {counts}"
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_conditional_multiscale_per_rule_count_matches_total(n_rules):
+    p = get_reward_presets("conditional_multiscale", ndim=6, height=64)[f"K{n_rules}"]
+    env = _make_env(
+        "conditional_multiscale", p, ndim=6, height=64, validate_modes=False
+    )
+    rf = env.reward_fn
+    total = rf.analytic_mode_count()
+    per_rule = rf.analytic_mode_count(per_rule=True)
+    assert per_rule * rf.n_rules == total
+
+
+def test_conditional_multiscale_selector_covers_all_rules():
+    """Selector must produce every rule index in [0, n_rules) over uniform
+    random states (else _validate_rule_coverage failed silently)."""
+    p = get_reward_presets("conditional_multiscale", ndim=6, height=64)["K64"]
+    env = _make_env(
+        "conditional_multiscale", p, ndim=6, height=64, validate_modes=False
+    )
+    rf = env.reward_fn
+    torch.manual_seed(0)
+    xs = torch.randint(0, 64, (200_000, 6))
+    msd = (xs // (rf.base ** (rf.num_levels - 1))) % rf.base
+    rule_idx = rf._selector(msd[..., rf.active_dims].long())
+    assert rule_idx.unique().numel() == rf.n_rules
+
+
+def test_conditional_multiscale_selector_deterministic():
+    p = get_reward_presets("conditional_multiscale", ndim=6, height=64)["K16"]
+    env = _make_env(
+        "conditional_multiscale", p, ndim=6, height=64, validate_modes=False
+    )
+    rf = env.reward_fn
+    torch.manual_seed(123)
+    xs = torch.randint(0, 64, (1024, 6))
+    msd = (xs // (rf.base ** (rf.num_levels - 1))) % rf.base
+    a = rf._selector(msd[..., rf.active_dims].long())
+    b = rf._selector(msd[..., rf.active_dims].long())
+    assert torch.equal(a, b)
+
+
+def test_conditional_multiscale_K1_matches_single_rule_at_same_head_seed():
+    """K=1 with head_seed=H is bit-exact equivalent to the original single-rule
+    reward when its `seed=H`. This is the API consistency property: the K-rule
+    code path collapses to the legacy reward at K=1."""
+    base_kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0],
+        base=4,
+        filter_width=2,
+        seed=2025,
+        active_dims=[0, 1, 2, 3, 4, 5],
+        cross_dim_mods=[2, 2, 2],
+    )
+    # Path A: legacy single-rule (n_rules unset -> defaults to 1, head_seed defaults to seed).
+    env_a = _make_env("conditional_multiscale", base_kwargs, ndim=6, height=64)
+    # Path B: explicit K=1 with head_seed equal to seed.
+    env_b_kwargs = dict(base_kwargs, n_rules=1, head_seed=2025)
+    env_b = _make_env("conditional_multiscale", env_b_kwargs, ndim=6, height=64)
+
+    torch.manual_seed(0)
+    xs = torch.randint(0, 64, (1024, 6))
+    r_a = env_a.reward_fn(xs)
+    r_b = env_b.reward_fn(xs)
+    assert torch.allclose(r_a, r_b, atol=0.0, rtol=0.0)
+
+
+def test_conditional_multiscale_rule_coverage_assert_fires():
+    # n_rules > f^d_active should raise — some rules unreachable.
+    bad = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        active_dims=[0, 1],  # f^d_active = 4
+        n_rules=8,           # exceeds 4
+    )
+    with pytest.raises(ValueError):
+        HyperGrid(
+            ndim=2,
+            height=16,
+            reward_fn_str="conditional_multiscale",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
+        )
+
+
+def test_conditional_multiscale_K1_with_distinct_head_seed():
+    """K=1 with head_seed=H (and seed=S, S != H) reproduces a fresh single-rule
+    reward initialized at seed=H — i.e. head_seed actually drives the head."""
+    common = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0],
+        base=4,
+        filter_width=2,
+        active_dims=[0, 1, 2, 3],
+    )
+    env_a = _make_env(
+        "conditional_multiscale", dict(common, seed=999), ndim=4, height=64
+    )
+    env_b = _make_env(
+        "conditional_multiscale",
+        dict(common, seed=42, n_rules=1, head_seed=999),
+        ndim=4,
+        height=64,
+    )
+    torch.manual_seed(0)
+    xs = torch.randint(0, 64, (1024, 4))
+    assert torch.equal(env_a.reward_fn(xs), env_b.reward_fn(xs))
+
+
+def test_conditional_multiscale_validator_rejects_dead_rules_via_cross_dim():
+    """K-rule template must not silently leave rules empty when cross_dim_mods[0]
+    shrinks the trunk-passing set below n_rules. Reproduces the audit blocker
+    that prompted dropping cross_dim_mods[0] from the K-rule template."""
+    bad = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        head_seed=2025,
+        active_dims=[0, 1, 2, 3, 4, 5],
+        cross_dim_mods=[2, 2, 2],   # tier-0 cross-dim halves trunk patterns
+        n_rules=64,                  # but selector mod 64 needs 64 distinct buckets
+    )
+    with pytest.raises(ValueError, match="trunk-passing"):
+        HyperGrid(
+            ndim=6,
+            height=64,
+            reward_fn_str="conditional_multiscale",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
+        )
+
+
+def test_conditional_multiscale_per_rule_raises_on_non_uniform_partition():
+    """analytic_mode_count(per_rule=True) must refuse to lie when the
+    partition is non-uniform (rules have unequal mode counts)."""
+    # f^d_active = 2^3 = 8; n_rules=3 doesn't divide 8 evenly (buckets: 3,3,2).
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        head_seed=99,
+        n_rules=3,
+        active_dims=[0, 1, 2],
+    )
+    env = HyperGrid(
+        ndim=3,
+        height=16,
+        reward_fn_str="conditional_multiscale",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
+    )
+    # Total count is fine.
+    assert env.reward_fn.analytic_mode_count() > 0
+    # Per-rule must raise — partition not uniform.
+    with pytest.raises(ValueError, match="uniform"):
+        env.reward_fn.analytic_mode_count(per_rule=True)
+
+
+def test_conditional_multiscale_K16_enumeration_parity():
+    """Direct enumeration: at K=16 on a small grid, the brute-force mode count
+    matches the analytic formula — testing the K-rule path beyond K<=4."""
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        head_seed=7,
+        n_rules=16,            # f^d_active = 2^4 = 16, exact partition
+        active_dims=[0, 1, 2, 3],
+    )
+    env = HyperGrid(
+        ndim=4,
+        height=16,
+        reward_fn_str="conditional_multiscale",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
+        store_all_states=True,
+    )
+    all_states = env.all_states
+    assert all_states is not None
+    rewards = env.reward_fn(all_states.tensor)
+    threshold = env.reward_fn.R0 + sum(env.reward_fn.tier_weights)
+    enum_count = int((rewards >= threshold - 1e-9).sum().item())
+    assert env.reward_fn.analytic_mode_count() == enum_count
+
+
+def test_conditional_multiscale_head_seed_none_raises():
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        head_seed=None,
+        active_dims=[0, 1],
+    )
+    with pytest.raises(ValueError, match="head_seed=None"):
+        HyperGrid(
+            ndim=2,
+            height=16,
+            reward_fn_str="conditional_multiscale",
+            reward_fn_kwargs=kwargs,
+            validate_modes=False,
+        )
+
+
+# -------------------------
+# BitwiseXORReward — K-rule trunk+heads
+# -------------------------
+
+
+def test_bitwise_xor_legacy_n_rules_default_is_1():
+    """Existing presets (no n_rules set) collapse to n_rules=1 with empty head."""
+    p = get_reward_presets("bitwise_xor", 10, 16)["medium"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16)
+    rf = env.reward_fn
+    assert rf.n_rules == 1
+    assert rf.head_check_count == 0
+    assert rf.head_weight == 0.0
+    assert rf.k_select == 0
+    M = len(rf.dims_constrained)
+    assert rf._head_A_per_rule.shape == (1, 0, M * rf._B)
+    assert rf._selector_matrix.shape == (0, M * rf._B)
+
+
+def test_bitwise_xor_legacy_reward_unchanged_by_refactor():
+    """Existing 'medium' preset reward output must be bit-identical at any state
+    to a hand-computed expectation. Locks in backward compat."""
+    p = get_reward_presets("bitwise_xor", 10, 16)["medium"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16)
+    # The all-zeros bit configuration trivially satisfies even-parity checks
+    # (when c_t = 0). Tier 0 in medium has c=[0]; tier 1 has c=[1, 0]; tier 2
+    # has c=[0]. With all-zero bits: tier 0 passes (Ab=0=c). Tier 1 first
+    # check: 0 != 1 → fails. So all-zeros gives R = R0 + tier_w[0] = 1.0.
+    xs = torch.zeros(1, 10, dtype=torch.long)
+    r = env.reward(env.States(xs))[0].item()
+    assert abs(r - 1.0) < 1e-6
+
+
+def test_bitwise_xor_K1_no_head_equals_legacy_over_random_batch():
+    """K=1 with empty head (head_check_count=0, head_weight=0) must produce
+    bit-identical reward to the legacy single-tier code path over a random
+    batch — confirms the K-rule code collapses cleanly."""
+    p = get_reward_presets("bitwise_xor", 10, 16)["medium"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=False)
+    rf = env.reward_fn
+    # Sanity: ensure this preset is in the n_rules=1 / no-head regime.
+    assert rf.n_rules == 1
+    assert rf.head_check_count == 0
+    assert rf.head_weight == 0.0
+    torch.manual_seed(0)
+    xs = torch.randint(0, 16, (2048, 10))
+    r = rf(xs)
+    # Recompute reward via the trunk-only formula (matches pre-refactor code).
+    # Only the constrained dims feed the parity check.
+    xs_constrained = xs[:, rf.dims_constrained]
+    flat_bits = (
+        (xs_constrained.unsqueeze(-1) >> torch.arange(rf._B)) & 1
+    ).reshape(2048, -1).long()
+    prod = (flat_bits @ rf._full_A.t()) & 1
+    expected = torch.full((2048,), float(rf.R0))
+    tier_ok = torch.ones(2048, dtype=torch.bool)
+    offset = 0
+    for n_chk, w in zip(rf._tier_check_counts, rf.tier_weights):
+        if n_chk > 0:
+            slice_ok = (
+                prod[..., offset : offset + n_chk]
+                == rf._full_c[offset : offset + n_chk]
+            ).all(-1)
+            tier_ok = tier_ok & slice_ok
+        expected = expected + tier_ok.float() * w
+        offset += n_chk
+    assert torch.allclose(r, expected, atol=0.0)
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_bitwise_xor_K_presets_validate_modes(n_rules):
+    p = get_reward_presets("bitwise_xor", 10, 16)[f"K{n_rules}"]
+    env = _make_env(
+        "bitwise_xor", p, ndim=10, height=16, validate_modes=True
+    )
+    assert env.reward_fn.n_rules == n_rules
+
+
+def test_bitwise_xor_density_invariant_in_K():
+    counts = []
+    for n_rules in (1, 16, 64):
+        p = get_reward_presets("bitwise_xor", 10, 16)[f"K{n_rules}"]
+        env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=False)
+        counts.append(env.reward_fn.analytic_mode_count())
+    assert len(set(counts)) == 1, f"mode counts vary with K: {counts}"
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_bitwise_xor_per_rule_count_matches_total(n_rules):
+    p = get_reward_presets("bitwise_xor", 10, 16)[f"K{n_rules}"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=False)
+    rf = env.reward_fn
+    total = rf.analytic_mode_count()
+    per_rule = rf.analytic_mode_count(per_rule=True)
+    assert per_rule * rf.n_rules == total
+
+
+def test_bitwise_xor_selector_covers_all_rules():
+    """Random-state samples must reach every rule in [0, n_rules)."""
+    p = get_reward_presets("bitwise_xor", 10, 16)["K64"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=False)
+    rf = env.reward_fn
+    torch.manual_seed(0)
+    xs = torch.randint(0, 16, (50_000, 10))
+    bits = ((xs.unsqueeze(-1) >> torch.arange(rf._B)) & 1).reshape(50_000, -1).long()
+    sel_bits = (bits @ rf._selector_matrix.t()) & 1
+    powers = 2 ** torch.arange(rf.k_select, dtype=torch.long)
+    rule_idx = (sel_bits * powers).sum(dim=-1) % rf.n_rules
+    assert rule_idx.unique().numel() == rf.n_rules
+
+
+def test_bitwise_xor_head_seed_required_when_K_gt_1():
+    """head_seed=None with n_rules > 1 must raise (no silent fallback)."""
+    bad = dict(
+        R0=0.0,
+        tier_weights=[1.0],
+        dims_constrained=[0, 1, 2],
+        bits_per_tier=[(0, 3)],
+        n_rules=4,
+    )
+    with pytest.raises(ValueError, match="head_seed"):
+        HyperGrid(
+            ndim=3, height=16, reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+def test_bitwise_xor_head_weight_nonzero_with_zero_check_count_raises():
+    bad = dict(
+        R0=0.0, tier_weights=[1.0], dims_constrained=[0, 1, 2],
+        bits_per_tier=[(0, 3)], n_rules=2, head_seed=1,
+        head_check_count=0, head_weight=10.0,
+    )
+    with pytest.raises(ValueError, match="head_check_count=0"):
+        HyperGrid(
+            ndim=3, height=16, reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+def test_bitwise_xor_validator_rejects_unreachable_rule():
+    """A degenerate K-rule config must be rejected at construction.
+
+    Setup: trunk pins all M*B bits to specific values (rank = M*B), so the
+    selector cannot find an independent matrix and witness construction fails.
+    The validator must raise — error message will mention either selector
+    independence or rule reachability depending on which check fires first.
+    """
+    M = 2
+    B = 2  # height=4
+    A_trunk = torch.eye(M * B, dtype=torch.long)
+    c_trunk = torch.zeros(M * B, dtype=torch.long)
+    bad = dict(
+        R0=0.0,
+        tier_weights=[1.0],
+        dims_constrained=[0, 1],
+        bits_per_tier=[(0, B - 1)],
+        parity_checks=[{"A": A_trunk, "c": c_trunk}],
+        n_rules=2,
+        head_seed=42,
+        head_check_count=1,
+        head_weight=10.0,
+        head_bit_range=(0, B - 1),
+    )
+    with pytest.raises(ValueError, match="selector|no solution|inconsistent"):
+        HyperGrid(
+            ndim=2, height=4, reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+# -------------------------
+# MultiplicativeCoprimeReward — K-rule trunk+heads
+# -------------------------
+
+
+def test_multiplicative_coprime_legacy_n_rules_default_is_1():
+    """Existing presets (no n_rules set) collapse to n_rules=1 with rule
+    target inherited from target_lcms[T-1] (auto)."""
+    p = get_reward_presets("multiplicative_coprime", 6, 64)["medium"]
+    env = _make_env("multiplicative_coprime", p, ndim=6, height=64)
+    rf = env.reward_fn
+    assert rf.n_rules == 1
+    assert rf.head_seed == 0
+    # medium has target_lcms=[None, None, None, "auto"] → auto LCM of
+    # primes={2,3,5,7} with cap=2 each = 4*9*25*49 = 44100.
+    assert rf.rule_targets == [44100]
+    assert rf.target_lcms[-1] == 44100
+
+
+def test_multiplicative_coprime_K1_no_head_seed_equals_legacy_over_random_batch():
+    """K=1 without head_seed (backward-compat path) must produce reward output
+    bit-identical to the pre-refactor single-LCM-target path. Locks in legacy
+    reward equivalence over a random batch."""
+    p = get_reward_presets("multiplicative_coprime", 6, 64)["medium"]
+    env = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
+    rf = env.reward_fn
+    # Sanity: this is the legacy regime (no head_seed, target_lcms[-1] retained).
+    assert rf.n_rules == 1
+    assert rf.head_seed == 0
+    assert rf.rule_targets == [44100]
+    assert rf.target_lcms[-1] == 44100
+    torch.manual_seed(0)
+    xs = torch.randint(0, 64, (2048, 6))
+    r = rf(xs)
+    # All rewards must be in the discrete set {R0, R0+w0, R0+w0+w1, ...}.
+    valid_rewards = {rf.R0}
+    cum = rf.R0
+    for w in rf.tier_weights:
+        cum += float(w)
+        valid_rewards.add(cum)
+    seen = set(round(x, 6) for x in r.tolist())
+    assert seen.issubset({round(v, 6) for v in valid_rewards}), (
+        f"unexpected reward values: {seen - {round(v, 6) for v in valid_rewards}}"
+    )
+    # And: there must be at least one tier-3 mode in 2048 samples? No — too
+    # rare. Instead: assert there are tier-1 passers (lots).
+    threshold_t1 = rf.R0 + float(rf.tier_weights[0])
+    assert (r >= threshold_t1).any()
+
+
+def test_multiplicative_coprime_K_presets_validate_modes():
+    for n_rules in (1, 16):
+        p = get_reward_presets("multiplicative_coprime", 6, 64)[f"K{n_rules}"]
+        env = _make_env(
+            "multiplicative_coprime", p, ndim=6, height=64, validate_modes=True
+        )
+        assert env.reward_fn.n_rules == n_rules
+
+
+def test_multiplicative_coprime_K16_distinct_rule_targets():
+    """All 16 rules at K=16 must have distinct LCM targets (the cap-tuple enum
+    yields 2^4=16 unique LCMs for primes={2,3,5,7})."""
+    p = get_reward_presets("multiplicative_coprime", 6, 64)["K16"]
+    env = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
+    assert len(set(env.reward_fn.rule_targets)) == 16
+
+
+def test_multiplicative_coprime_head_seed_required_when_K_gt_1():
+    bad = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0, 1000.0],
+        primes=[2, 3, 5, 7],
+        exponent_caps=[2, 2, 2, 2],
+        active_dims=[0, 1, 2, 3, 4, 5],
+        coprime_pairs=[(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)],
+        coprime_start_tier=2,
+        target_lcms=[None, None, None, None],
+        n_rules=4,
+        # head_seed missing
+    )
+    with pytest.raises(ValueError, match="head_seed"):
+        HyperGrid(
+            ndim=6, height=64, reward_fn_str="multiplicative_coprime",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+def test_multiplicative_coprime_too_few_primes_for_K_raises():
+    bad = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0, 1000.0],
+        primes=[2, 3],          # only 2 primes
+        exponent_caps=[2, 2, 2, 2],
+        active_dims=[0, 1],
+        coprime_pairs=[(0, 1)],
+        coprime_start_tier=2,
+        target_lcms=[None, None, None, None],
+        n_rules=16,             # 2^2 = 4 < 16
+        head_seed=42,
+    )
+    with pytest.raises(ValueError, match="Cannot generate"):
+        HyperGrid(
+            ndim=2, height=16, reward_fn_str="multiplicative_coprime",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+def test_multiplicative_coprime_K1_with_explicit_head_seed_uses_enum():
+    """K=1 with head_seed explicitly set uses the K-rule enum, not target_lcms.
+    Also verifies B1 fix: when the K-rule path is active, target_lcms[-1] is
+    cleared, so a state matching rule 0's head LCM is actually a mode (no
+    contradictory shared trunk LCM)."""
+    common = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0, 1000.0],
+        primes=[2, 3, 5, 7],
+        exponent_caps=[2, 2, 2, 2],
+        active_dims=[0, 1, 2, 3, 4, 5],
+        coprime_pairs=[(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)],
+        coprime_start_tier=2,
+        target_lcms=[None, None, None, "auto"],  # would yield 44100
+    )
+    # No head_seed: backward-compat path inherits 44100.
+    env_a = _make_env(
+        "multiplicative_coprime", common, ndim=6, height=64, validate_modes=False
+    )
+    assert env_a.reward_fn.rule_targets == [44100]
+    assert env_a.reward_fn.target_lcms[-1] == 44100  # NOT cleared
+    # With head_seed: K=1 uses enum entry, target_lcms[-1] cleared.
+    env_b = _make_env(
+        "multiplicative_coprime",
+        dict(common, n_rules=1, head_seed=2025),
+        ndim=6, height=64, validate_modes=True,  # validate must succeed
+    )
+    assert env_b.reward_fn.rule_targets[0] != 44100
+    assert env_b.reward_fn.target_lcms[-1] is None  # cleared by K-rule path
+
+
+def test_multiplicative_coprime_head_seed_reproducibility():
+    """Same head_seed → same rule_targets across constructions."""
+    p = get_reward_presets("multiplicative_coprime", 6, 64)["K16"]
+    env_a = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
+    env_b = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
+    assert env_a.reward_fn.rule_targets == env_b.reward_fn.rule_targets
+
+
+def test_multiplicative_coprime_explicit_rule_targets_bypass_generator():
+    """User-supplied rule_targets must be used as-is and clear target_lcms[-1]."""
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        primes=[2, 3],
+        exponent_caps=[2, 2],
+        active_dims=[0, 1],
+        coprime_pairs=[(0, 1)],
+        coprime_start_tier=1,
+        target_lcms=[None, "auto"],  # would yield 36 = 4*9
+        n_rules=2,
+        head_seed=42,
+        rule_targets=[6, 12],         # explicit — bypasses generator
+    )
+    env = HyperGrid(
+        ndim=2, height=16, reward_fn_str="multiplicative_coprime",
+        reward_fn_kwargs=kwargs, validate_modes=False,
+    )
+    assert env.reward_fn.rule_targets == [6, 12]
+    assert env.reward_fn.target_lcms[-1] is None  # K-rule path cleared it
+
+
+def test_multiplicative_coprime_rule_targets_with_None_uses_sentinel():
+    """A rule with rule_targets[k]=None (no head LCM constraint) must pass
+    the head check trivially via the -1 sentinel."""
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        primes=[2, 3],
+        exponent_caps=[2, 2],
+        active_dims=[0, 1],
+        coprime_pairs=[(0, 1)],
+        coprime_start_tier=1,
+        target_lcms=[None, None],
+        n_rules=2,
+        head_seed=42,
+        rule_targets=[None, 6],
+    )
+    env = HyperGrid(
+        ndim=2, height=16, reward_fn_str="multiplicative_coprime",
+        reward_fn_kwargs=kwargs, validate_modes=False,
+    )
+    rf = env.reward_fn
+    # Rule 0's exps are all -1 sentinel.
+    assert (rf._rule_target_exps[0] == -1).all()
+    # Rule 1's exps are factorization of 6: 2^1 * 3^1.
+    assert rf._rule_target_exps[1].tolist() == [1, 1]
+
+
+def test_multiplicative_coprime_density_within_2x_K1_K16():
+    """Empirical density of K1 and K16 must be within 2x at the shipped
+    presets (research-code contract: density approximately invariant)."""
+    torch.manual_seed(0)
+    xs = torch.randint(0, 64, (1_000_000, 6))
+    densities = []
+    for n_rules in (1, 16):
+        p = get_reward_presets("multiplicative_coprime", 6, 64)[f"K{n_rules}"]
+        env = _make_env(
+            "multiplicative_coprime", p, ndim=6, height=64, validate_modes=False
+        )
+        rf = env.reward_fn
+        r = rf(xs)
+        threshold = sum(rf.tier_weights) + rf.R0
+        densities.append((r >= threshold).float().mean().item())
+    # Both should be > 0; ratio within 4x in either direction.
+    assert all(d > 0 for d in densities), f"K1 or K16 has 0 mode density: {densities}"
+    ratio = max(densities) / min(densities)
+    assert ratio <= 4.0, f"K1/K16 density ratio = {ratio}: not approximately invariant"
+
+
+def test_multiplicative_coprime_exists_check_K_rule_path():
+    """At K>1 with a large grid, _exists_multiplicative_coprime must find at
+    least one rule with a witness whose selector maps back to its index."""
+    p = get_reward_presets("multiplicative_coprime", 6, 64)["K16"]
+    env = _make_env(
+        "multiplicative_coprime", p, ndim=6, height=64, validate_modes=False
+    )
+    thr = env._mode_reward_threshold()
+    assert env._exists_multiplicative_coprime(thr) is True
+
+
+def test_multiplicative_coprime_selector_covers_all_rules():
+    p = get_reward_presets("multiplicative_coprime", 6, 64)["K16"]
+    env = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
+    rf = env.reward_fn
+    torch.manual_seed(0)
+    xs = torch.randint(0, 64, (50_000, 6))
+    x_active = xs[:, rf.active_dims] + 1
+    rule_idx = rf._selector(x_active)
+    assert rule_idx.unique().numel() == rf.n_rules
+
+
+def test_multiplicative_coprime_K16_enumeration_parity():
+    """On a small grid, brute-force mode count equals analytic threshold count."""
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        primes=[2, 3],
+        exponent_caps=[2, 2],
+        active_dims=[0, 1, 2],
+        coprime_pairs=[(0, 1), (1, 2)],
+        coprime_start_tier=1,
+        target_lcms=[None, None],
+        n_rules=4,
+        head_seed=42,
+    )
+    env = HyperGrid(
+        ndim=3, height=16, reward_fn_str="multiplicative_coprime",
+        reward_fn_kwargs=kwargs, validate_modes=False, store_all_states=True,
+    )
+    all_states = env.all_states
+    assert all_states is not None
+    rewards = env.reward_fn(all_states.tensor)
+    threshold = sum(env.reward_fn.tier_weights) + env.reward_fn.R0
+    enum_count = int((rewards >= threshold - 1e-9).sum().item())
+    # Each rule with non-trivial LCM target has at least one mode.
+    assert enum_count > 0
+
+
+def test_solve_gf2_witness_basic_cases():
+    """Direct unit tests for HyperGrid._solve_gf2_witness."""
+    # Empty system: any vector is a solution.
+    A = torch.zeros(0, 5, dtype=torch.long)
+    c = torch.zeros(0, dtype=torch.long)
+    b = HyperGrid._solve_gf2_witness(A, c, 5)
+    assert b is not None and torch.all(b == 0)
+
+    # 1-equation system: x0 = 1.
+    A = torch.tensor([[1, 0]], dtype=torch.long)
+    c = torch.tensor([1], dtype=torch.long)
+    b = HyperGrid._solve_gf2_witness(A, c, 2)
+    assert b is not None and ((A.long() @ b.long()) & 1 == c).all()
+
+    # Inconsistent: 0·x = 1 → no solution.
+    A = torch.tensor([[0, 0]], dtype=torch.long)
+    c = torch.tensor([1], dtype=torch.long)
+    assert HyperGrid._solve_gf2_witness(A, c, 2) is None
+
+    # Redundant rows: x0 + x1 = 1, 2·(x0 + x1) = 0 (in GF(2): same row twice → consistent).
+    A = torch.tensor([[1, 1], [1, 1]], dtype=torch.long)
+    c = torch.tensor([1, 1], dtype=torch.long)
+    b = HyperGrid._solve_gf2_witness(A, c, 2)
+    assert b is not None and ((A.long() @ b.long()) & 1 == c).all()
+
+    # Redundant rows with conflict: x0+x1=1, x0+x1=0 → inconsistent.
+    A = torch.tensor([[1, 1], [1, 1]], dtype=torch.long)
+    c = torch.tensor([1, 0], dtype=torch.long)
+    assert HyperGrid._solve_gf2_witness(A, c, 2) is None
+
+
+def test_bitwise_xor_K1_with_head_is_validated():
+    """K=1 with head_check_count > 0 must trigger _validate_rule_coverage
+    (witness construction must succeed for the single rule)."""
+    p = get_reward_presets("bitwise_xor", 10, 16)["K1"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=True)
+    rf = env.reward_fn
+    assert rf.n_rules == 1
+    assert rf.head_check_count == 1
+    assert rf.head_weight == 1000.0
+    # Witness construction must have set head_c[0] consistently.
+    # Verify: there exists a state with reward equal to the full mode threshold.
+    threshold = rf.R0 + sum(rf.tier_weights) + rf.head_weight
+    # For this preset, an explicit mode is hard to construct without enumeration,
+    # but the analytic count > 0 implies one exists.
+    assert rf.analytic_mode_count() > 0
+
+
+def test_bitwise_xor_K1_head_seed_required():
+    """At K=1 with head_check_count > 0, head_seed=None must raise."""
+    bad = dict(
+        R0=0.0, tier_weights=[1.0], dims_constrained=[0, 1, 2],
+        bits_per_tier=[(0, 3)],
+        n_rules=1,
+        head_check_count=1, head_weight=10.0,
+        # head_seed missing
+    )
+    with pytest.raises(ValueError, match="head_seed"):
+        HyperGrid(
+            ndim=3, height=16, reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+def test_bitwise_xor_empty_head_bit_range_with_count_raises():
+    bad = dict(
+        R0=0.0, tier_weights=[1.0], dims_constrained=[0, 1, 2],
+        bits_per_tier=[(0, 3)], n_rules=2, head_seed=1,
+        head_check_count=1, head_weight=10.0,
+        head_bit_range=(0, -1),  # empty range
+    )
+    with pytest.raises(AssertionError, match="head_bit_range"):
+        HyperGrid(
+            ndim=3, height=16, reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad, validate_modes=False,
+        )
+
+
+def test_bitwise_xor_K_enumeration_parity():
+    """Brute-force enumeration must match analytic_mode_count on a small grid."""
+    M = 4
+    B = 2  # height=4
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0],
+        dims_constrained=[0, 1, 2, 3],
+        bits_per_tier=[(0, B - 1)],
+        parity_checks=[None],  # default even parity
+        n_rules=4,
+        head_seed=99,
+        head_check_count=1,
+        head_weight=10.0,
+        head_bit_range=(0, B - 1),
+    )
+    env = HyperGrid(
+        ndim=4, height=4, reward_fn_str="bitwise_xor",
+        reward_fn_kwargs=kwargs, validate_modes=False, store_all_states=True,
+    )
+    all_states = env.all_states
+    assert all_states is not None
+    rewards = env.reward_fn(all_states.tensor)
+    threshold = sum(env.reward_fn.tier_weights) + env.reward_fn.head_weight
+    enum_count = int((rewards >= threshold - 1e-9).sum().item())
+    assert env.reward_fn.analytic_mode_count() == enum_count
+
+
+def test_conditional_multiscale_analytic_matches_enumeration_K():
+    """At a small grid, analytic_mode_count must equal a brute-force count of
+    states reaching the highest tier. Tests the K-rule path explicitly."""
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        head_seed=99,
+        n_rules=4,                  # f^d_active = 2^3 = 8 ≥ 4
+        active_dims=[0, 1, 2],
+    )
+    # 16x16x16 grid (4^2 each): state space = 4096. Easily enumerable.
+    env = HyperGrid(
+        ndim=3,
+        height=16,
+        reward_fn_str="conditional_multiscale",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
+        store_all_states=True,
+    )
+    all_states = env.all_states
+    assert all_states is not None
+    rewards = env.reward_fn(all_states.tensor)
+    threshold = env.reward_fn.R0 + sum(env.reward_fn.tier_weights)
+    enum_count = int((rewards >= threshold - 1e-9).sum().item())
+    analytic = env.reward_fn.analytic_mode_count()
+    assert analytic == enum_count
+
+
+# -------------------------
+# ConditionalMultiScale filter_shift coverage knob
+# -------------------------
+
+
+def test_multiscale_filter_shift_default_is_zero_and_unchanged():
+    """Without filter_shift, the trunk passes top_digit < f starting at 0
+    (current behavior)."""
+    kwargs = dict(R0=0.0, tier_weights=[1.0, 10.0], base=4, filter_width=2,
+                  seed=42, active_dims=[0, 1])
+    env = _make_env("conditional_multiscale", kwargs, ndim=2, height=16)
+    rf = env.reward_fn
+    assert rf.filter_shift == [0, 0]
+    # All-zeros state passes (default behavior preserved).
+    xs = torch.zeros(1, 2, dtype=torch.long)
+    r = env.reward_fn(xs)[0].item()
+    assert r >= rf.R0 + sum(rf.tier_weights) - 1e-6
+
+
+def test_multiscale_filter_shift_moves_blind_strip():
+    """filter_shift[0]=k cyclically rotates the trunk-passing top-digit
+    block: passing values become {(B-k) mod B, (B-k+1) mod B, ..., (B-k+f-1) mod B}."""
+    base = 4
+    f = 3
+    L = 2  # h=16
+    H = base ** L
+    # filter_shift[0] = 1: passing top-digits are {3, 0, 1} (excludes 2).
+    kwargs = dict(R0=0.0, tier_weights=[1.0, 10.0], base=base, filter_width=f,
+                  seed=42, active_dims=[0, 1], filter_shift=[1, 0])
+    env = _make_env("conditional_multiscale", kwargs, ndim=2, height=H)
+    rf = env.reward_fn
+
+    # Tier-0 should pass for top-digit ∈ {0, 1, 3} and FAIL for top-digit==2.
+    # Top digit = state // base^(L-1) = state // 4 in [0, 4).
+    for top_digit in range(base):
+        v = top_digit * (base ** (L - 1))  # represents top digit specifically
+        xs = torch.tensor([[v, v]], dtype=torch.long)
+        r = env.reward_fn(xs)[0].item()
+        passes_tier0 = (top_digit + 1) % base < f  # 1 == filter_shift[0]
+        assert (r > rf.R0) == passes_tier0, (
+            f"top_digit={top_digit}, expected pass_t0={passes_tier0}, got reward={r}"
+        )
+
+
+def test_multiscale_filter_shift_density_invariant():
+    """Density (analytic_mode_count) is invariant under filter_shift —
+    the shift cyclically rotates the passing window without changing |window|."""
+    base_kwargs = dict(R0=0.0, tier_weights=[1.0, 10.0, 100.0], base=4,
+                       filter_width=3, seed=42, head_seed=2025,
+                       active_dims=list(range(8)),
+                       cross_dim_mods=[None, 3, 3], n_rules=1)
+    counts = []
+    for fs0 in range(4):
+        kw = dict(base_kwargs, filter_shift=[fs0, 0, 0])
+        env = _make_env("conditional_multiscale", kw, ndim=8, height=64,
+                        validate_modes=False)
+        counts.append(env.reward_fn.analytic_mode_count())
+    assert len(set(counts)) == 1, f"density varies under filter_shift: {counts}"
+
+
+# -------------------------
+# K-rule "matched" presets — production-grade matched-density at K=64
+# -------------------------
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_multiscale_K_matched_validate_modes(n_rules):
+    p = get_reward_presets("conditional_multiscale", 24, 16)[f"K{n_rules}_matched"]
+    env = _make_env(
+        "conditional_multiscale", p, ndim=24, height=16, validate_modes=True
+    )
+    assert env.reward_fn.n_rules == n_rules
+    total = env.reward_fn.analytic_mode_count()
+    density = total / 16**24
+    # Target ~1e-7; allow 0.5e-7 to 5e-7.
+    assert 5e-8 < density < 5e-7, f"density {density:.2e} out of expected matched range"
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_bitxor_K_matched_validate_modes(n_rules):
+    p = get_reward_presets("bitwise_xor", 10, 16)[f"K{n_rules}_matched"]
+    env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=True)
+    assert env.reward_fn.n_rules == n_rules
+    total = env.reward_fn.analytic_mode_count()
+    density = total / 16**10
+    assert 5e-8 < density < 5e-7, f"density {density:.2e} out of expected matched range"
+
+
+@pytest.mark.parametrize("n_rules", [1, 16, 64])
+def test_coprime_K_matched_validate_modes(n_rules):
+    """Coprime matched: validate_modes via _exists_multiplicative_coprime
+    constructs a witness for trunk LCM=44100. No analytic count; just confirm
+    construction + at least one mode exists."""
+    p = get_reward_presets("multiplicative_coprime", 10, 64)[f"K{n_rules}_matched"]
+    env = _make_env(
+        "multiplicative_coprime", p, ndim=10, height=64, validate_modes=True
+    )
+    assert env.reward_fn.n_rules == n_rules

--- a/testing/test_hypergrid.py
+++ b/testing/test_hypergrid.py
@@ -520,9 +520,7 @@ def test_conditional_multiscale_density_invariant_in_K():
 @pytest.mark.parametrize("n_rules", [1, 16, 64])
 def test_conditional_multiscale_per_rule_count_matches_total(n_rules):
     p = get_reward_presets("conditional_multiscale", ndim=6, height=64)[f"K{n_rules}"]
-    env = _make_env(
-        "conditional_multiscale", p, ndim=6, height=64, validate_modes=False
-    )
+    env = _make_env("conditional_multiscale", p, ndim=6, height=64, validate_modes=False)
     rf = env.reward_fn
     total = rf.analytic_mode_count()
     per_rule = rf.analytic_mode_count(per_rule=True)
@@ -533,9 +531,7 @@ def test_conditional_multiscale_selector_covers_all_rules():
     """Selector must produce every rule index in [0, n_rules) over uniform
     random states (else _validate_rule_coverage failed silently)."""
     p = get_reward_presets("conditional_multiscale", ndim=6, height=64)["K64"]
-    env = _make_env(
-        "conditional_multiscale", p, ndim=6, height=64, validate_modes=False
-    )
+    env = _make_env("conditional_multiscale", p, ndim=6, height=64, validate_modes=False)
     rf = env.reward_fn
     torch.manual_seed(0)
     xs = torch.randint(0, 64, (200_000, 6))
@@ -546,9 +542,7 @@ def test_conditional_multiscale_selector_covers_all_rules():
 
 def test_conditional_multiscale_selector_deterministic():
     p = get_reward_presets("conditional_multiscale", ndim=6, height=64)["K16"]
-    env = _make_env(
-        "conditional_multiscale", p, ndim=6, height=64, validate_modes=False
-    )
+    env = _make_env("conditional_multiscale", p, ndim=6, height=64, validate_modes=False)
     rf = env.reward_fn
     torch.manual_seed(123)
     xs = torch.randint(0, 64, (1024, 6))
@@ -593,7 +587,7 @@ def test_conditional_multiscale_rule_coverage_assert_fires():
         filter_width=2,
         seed=42,
         active_dims=[0, 1],  # f^d_active = 4
-        n_rules=8,           # exceeds 4
+        n_rules=8,  # exceeds 4
     )
     with pytest.raises(ValueError):
         HyperGrid(
@@ -641,8 +635,8 @@ def test_conditional_multiscale_validator_rejects_dead_rules_via_cross_dim():
         seed=42,
         head_seed=2025,
         active_dims=[0, 1, 2, 3, 4, 5],
-        cross_dim_mods=[2, 2, 2],   # tier-0 cross-dim halves trunk patterns
-        n_rules=64,                  # but selector mod 64 needs 64 distinct buckets
+        cross_dim_mods=[2, 2, 2],  # tier-0 cross-dim halves trunk patterns
+        n_rules=64,  # but selector mod 64 needs 64 distinct buckets
     )
     with pytest.raises(ValueError, match="trunk-passing"):
         HyperGrid(
@@ -692,7 +686,7 @@ def test_conditional_multiscale_K16_enumeration_parity():
         filter_width=2,
         seed=42,
         head_seed=7,
-        n_rules=16,            # f^d_active = 2^4 = 16, exact partition
+        n_rules=16,  # f^d_active = 2^4 = 16, exact partition
         active_dims=[0, 1, 2, 3],
     )
     env = HyperGrid(
@@ -782,8 +776,10 @@ def test_bitwise_xor_K1_no_head_equals_legacy_over_random_batch():
     # Only the constrained dims feed the parity check.
     xs_constrained = xs[:, rf.dims_constrained]
     flat_bits = (
-        (xs_constrained.unsqueeze(-1) >> torch.arange(rf._B)) & 1
-    ).reshape(2048, -1).long()
+        ((xs_constrained.unsqueeze(-1) >> torch.arange(rf._B)) & 1)
+        .reshape(2048, -1)
+        .long()
+    )
     prod = (flat_bits @ rf._full_A.t()) & 1
     expected = torch.full((2048,), float(rf.R0))
     tier_ok = torch.ones(2048, dtype=torch.bool)
@@ -791,8 +787,7 @@ def test_bitwise_xor_K1_no_head_equals_legacy_over_random_batch():
     for n_chk, w in zip(rf._tier_check_counts, rf.tier_weights):
         if n_chk > 0:
             slice_ok = (
-                prod[..., offset : offset + n_chk]
-                == rf._full_c[offset : offset + n_chk]
+                prod[..., offset : offset + n_chk] == rf._full_c[offset : offset + n_chk]
             ).all(-1)
             tier_ok = tier_ok & slice_ok
         expected = expected + tier_ok.float() * w
@@ -803,9 +798,7 @@ def test_bitwise_xor_K1_no_head_equals_legacy_over_random_batch():
 @pytest.mark.parametrize("n_rules", [1, 16, 64])
 def test_bitwise_xor_K_presets_validate_modes(n_rules):
     p = get_reward_presets("bitwise_xor", 10, 16)[f"K{n_rules}"]
-    env = _make_env(
-        "bitwise_xor", p, ndim=10, height=16, validate_modes=True
-    )
+    env = _make_env("bitwise_xor", p, ndim=10, height=16, validate_modes=True)
     assert env.reward_fn.n_rules == n_rules
 
 
@@ -853,21 +846,32 @@ def test_bitwise_xor_head_seed_required_when_K_gt_1():
     )
     with pytest.raises(ValueError, match="head_seed"):
         HyperGrid(
-            ndim=3, height=16, reward_fn_str="bitwise_xor",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=3,
+            height=16,
+            reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
 def test_bitwise_xor_head_weight_nonzero_with_zero_check_count_raises():
     bad = dict(
-        R0=0.0, tier_weights=[1.0], dims_constrained=[0, 1, 2],
-        bits_per_tier=[(0, 3)], n_rules=2, head_seed=1,
-        head_check_count=0, head_weight=10.0,
+        R0=0.0,
+        tier_weights=[1.0],
+        dims_constrained=[0, 1, 2],
+        bits_per_tier=[(0, 3)],
+        n_rules=2,
+        head_seed=1,
+        head_check_count=0,
+        head_weight=10.0,
     )
     with pytest.raises(ValueError, match="head_check_count=0"):
         HyperGrid(
-            ndim=3, height=16, reward_fn_str="bitwise_xor",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=3,
+            height=16,
+            reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
@@ -897,8 +901,11 @@ def test_bitwise_xor_validator_rejects_unreachable_rule():
     )
     with pytest.raises(ValueError, match="selector|no solution|inconsistent"):
         HyperGrid(
-            ndim=2, height=4, reward_fn_str="bitwise_xor",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=2,
+            height=4,
+            reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
@@ -943,9 +950,9 @@ def test_multiplicative_coprime_K1_no_head_seed_equals_legacy_over_random_batch(
         cum += float(w)
         valid_rewards.add(cum)
     seen = set(round(x, 6) for x in r.tolist())
-    assert seen.issubset({round(v, 6) for v in valid_rewards}), (
-        f"unexpected reward values: {seen - {round(v, 6) for v in valid_rewards}}"
-    )
+    assert seen.issubset(
+        {round(v, 6) for v in valid_rewards}
+    ), f"unexpected reward values: {seen - {round(v, 6) for v in valid_rewards}}"
     # And: there must be at least one tier-3 mode in 2048 samples? No — too
     # rare. Instead: assert there are tier-1 passers (lots).
     threshold_t1 = rf.R0 + float(rf.tier_weights[0])
@@ -984,8 +991,11 @@ def test_multiplicative_coprime_head_seed_required_when_K_gt_1():
     )
     with pytest.raises(ValueError, match="head_seed"):
         HyperGrid(
-            ndim=6, height=64, reward_fn_str="multiplicative_coprime",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=6,
+            height=64,
+            reward_fn_str="multiplicative_coprime",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
@@ -993,19 +1003,22 @@ def test_multiplicative_coprime_too_few_primes_for_K_raises():
     bad = dict(
         R0=0.0,
         tier_weights=[1.0, 10.0, 100.0, 1000.0],
-        primes=[2, 3],          # only 2 primes
+        primes=[2, 3],  # only 2 primes
         exponent_caps=[2, 2, 2, 2],
         active_dims=[0, 1],
         coprime_pairs=[(0, 1)],
         coprime_start_tier=2,
         target_lcms=[None, None, None, None],
-        n_rules=16,             # 2^2 = 4 < 16
+        n_rules=16,  # 2^2 = 4 < 16
         head_seed=42,
     )
     with pytest.raises(ValueError, match="Cannot generate"):
         HyperGrid(
-            ndim=2, height=16, reward_fn_str="multiplicative_coprime",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=2,
+            height=16,
+            reward_fn_str="multiplicative_coprime",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
@@ -1034,7 +1047,9 @@ def test_multiplicative_coprime_K1_with_explicit_head_seed_uses_enum():
     env_b = _make_env(
         "multiplicative_coprime",
         dict(common, n_rules=1, head_seed=2025),
-        ndim=6, height=64, validate_modes=True,  # validate must succeed
+        ndim=6,
+        height=64,
+        validate_modes=True,  # validate must succeed
     )
     assert env_b.reward_fn.rule_targets[0] != 44100
     assert env_b.reward_fn.target_lcms[-1] is None  # cleared by K-rule path
@@ -1043,8 +1058,12 @@ def test_multiplicative_coprime_K1_with_explicit_head_seed_uses_enum():
 def test_multiplicative_coprime_head_seed_reproducibility():
     """Same head_seed → same rule_targets across constructions."""
     p = get_reward_presets("multiplicative_coprime", 6, 64)["K16"]
-    env_a = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
-    env_b = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
+    env_a = _make_env(
+        "multiplicative_coprime", p, ndim=6, height=64, validate_modes=False
+    )
+    env_b = _make_env(
+        "multiplicative_coprime", p, ndim=6, height=64, validate_modes=False
+    )
     assert env_a.reward_fn.rule_targets == env_b.reward_fn.rule_targets
 
 
@@ -1061,11 +1080,14 @@ def test_multiplicative_coprime_explicit_rule_targets_bypass_generator():
         target_lcms=[None, "auto"],  # would yield 36 = 4*9
         n_rules=2,
         head_seed=42,
-        rule_targets=[6, 12],         # explicit — bypasses generator
+        rule_targets=[6, 12],  # explicit — bypasses generator
     )
     env = HyperGrid(
-        ndim=2, height=16, reward_fn_str="multiplicative_coprime",
-        reward_fn_kwargs=kwargs, validate_modes=False,
+        ndim=2,
+        height=16,
+        reward_fn_str="multiplicative_coprime",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
     )
     assert env.reward_fn.rule_targets == [6, 12]
     assert env.reward_fn.target_lcms[-1] is None  # K-rule path cleared it
@@ -1088,8 +1110,11 @@ def test_multiplicative_coprime_rule_targets_with_None_uses_sentinel():
         rule_targets=[None, 6],
     )
     env = HyperGrid(
-        ndim=2, height=16, reward_fn_str="multiplicative_coprime",
-        reward_fn_kwargs=kwargs, validate_modes=False,
+        ndim=2,
+        height=16,
+        reward_fn_str="multiplicative_coprime",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
     )
     rf = env.reward_fn
     # Rule 0's exps are all -1 sentinel.
@@ -1123,9 +1148,7 @@ def test_multiplicative_coprime_exists_check_K_rule_path():
     """At K>1 with a large grid, _exists_multiplicative_coprime must find at
     least one rule with a witness whose selector maps back to its index."""
     p = get_reward_presets("multiplicative_coprime", 6, 64)["K16"]
-    env = _make_env(
-        "multiplicative_coprime", p, ndim=6, height=64, validate_modes=False
-    )
+    env = _make_env("multiplicative_coprime", p, ndim=6, height=64, validate_modes=False)
     thr = env._mode_reward_threshold()
     assert env._exists_multiplicative_coprime(thr) is True
 
@@ -1156,8 +1179,12 @@ def test_multiplicative_coprime_K16_enumeration_parity():
         head_seed=42,
     )
     env = HyperGrid(
-        ndim=3, height=16, reward_fn_str="multiplicative_coprime",
-        reward_fn_kwargs=kwargs, validate_modes=False, store_all_states=True,
+        ndim=3,
+        height=16,
+        reward_fn_str="multiplicative_coprime",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
+        store_all_states=True,
     )
     all_states = env.all_states
     assert all_states is not None
@@ -1208,47 +1235,58 @@ def test_bitwise_xor_K1_with_head_is_validated():
     assert rf.n_rules == 1
     assert rf.head_check_count == 1
     assert rf.head_weight == 1000.0
-    # Witness construction must have set head_c[0] consistently.
-    # Verify: there exists a state with reward equal to the full mode threshold.
-    threshold = rf.R0 + sum(rf.tier_weights) + rf.head_weight
-    # For this preset, an explicit mode is hard to construct without enumeration,
-    # but the analytic count > 0 implies one exists.
+    # Witness construction must have set head_c[0] consistently. An explicit
+    # mode is hard to construct without enumeration, but the analytic count
+    # > 0 implies one exists at threshold R0 + sum(tier_weights) + head_weight.
     assert rf.analytic_mode_count() > 0
 
 
 def test_bitwise_xor_K1_head_seed_required():
     """At K=1 with head_check_count > 0, head_seed=None must raise."""
     bad = dict(
-        R0=0.0, tier_weights=[1.0], dims_constrained=[0, 1, 2],
+        R0=0.0,
+        tier_weights=[1.0],
+        dims_constrained=[0, 1, 2],
         bits_per_tier=[(0, 3)],
         n_rules=1,
-        head_check_count=1, head_weight=10.0,
+        head_check_count=1,
+        head_weight=10.0,
         # head_seed missing
     )
     with pytest.raises(ValueError, match="head_seed"):
         HyperGrid(
-            ndim=3, height=16, reward_fn_str="bitwise_xor",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=3,
+            height=16,
+            reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
 def test_bitwise_xor_empty_head_bit_range_with_count_raises():
     bad = dict(
-        R0=0.0, tier_weights=[1.0], dims_constrained=[0, 1, 2],
-        bits_per_tier=[(0, 3)], n_rules=2, head_seed=1,
-        head_check_count=1, head_weight=10.0,
+        R0=0.0,
+        tier_weights=[1.0],
+        dims_constrained=[0, 1, 2],
+        bits_per_tier=[(0, 3)],
+        n_rules=2,
+        head_seed=1,
+        head_check_count=1,
+        head_weight=10.0,
         head_bit_range=(0, -1),  # empty range
     )
     with pytest.raises(AssertionError, match="head_bit_range"):
         HyperGrid(
-            ndim=3, height=16, reward_fn_str="bitwise_xor",
-            reward_fn_kwargs=bad, validate_modes=False,
+            ndim=3,
+            height=16,
+            reward_fn_str="bitwise_xor",
+            reward_fn_kwargs=bad,
+            validate_modes=False,
         )
 
 
 def test_bitwise_xor_K_enumeration_parity():
     """Brute-force enumeration must match analytic_mode_count on a small grid."""
-    M = 4
     B = 2  # height=4
     kwargs = dict(
         R0=0.0,
@@ -1263,8 +1301,12 @@ def test_bitwise_xor_K_enumeration_parity():
         head_bit_range=(0, B - 1),
     )
     env = HyperGrid(
-        ndim=4, height=4, reward_fn_str="bitwise_xor",
-        reward_fn_kwargs=kwargs, validate_modes=False, store_all_states=True,
+        ndim=4,
+        height=4,
+        reward_fn_str="bitwise_xor",
+        reward_fn_kwargs=kwargs,
+        validate_modes=False,
+        store_all_states=True,
     )
     all_states = env.all_states
     assert all_states is not None
@@ -1284,7 +1326,7 @@ def test_conditional_multiscale_analytic_matches_enumeration_K():
         filter_width=2,
         seed=42,
         head_seed=99,
-        n_rules=4,                  # f^d_active = 2^3 = 8 ≥ 4
+        n_rules=4,  # f^d_active = 2^3 = 8 ≥ 4
         active_dims=[0, 1, 2],
     )
     # 16x16x16 grid (4^2 each): state space = 4096. Easily enumerable.
@@ -1313,8 +1355,14 @@ def test_conditional_multiscale_analytic_matches_enumeration_K():
 def test_multiscale_filter_shift_default_is_zero_and_unchanged():
     """Without filter_shift, the trunk passes top_digit < f starting at 0
     (current behavior)."""
-    kwargs = dict(R0=0.0, tier_weights=[1.0, 10.0], base=4, filter_width=2,
-                  seed=42, active_dims=[0, 1])
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=4,
+        filter_width=2,
+        seed=42,
+        active_dims=[0, 1],
+    )
     env = _make_env("conditional_multiscale", kwargs, ndim=2, height=16)
     rf = env.reward_fn
     assert rf.filter_shift == [0, 0]
@@ -1330,10 +1378,17 @@ def test_multiscale_filter_shift_moves_blind_strip():
     base = 4
     f = 3
     L = 2  # h=16
-    H = base ** L
+    H = base**L
     # filter_shift[0] = 1: passing top-digits are {3, 0, 1} (excludes 2).
-    kwargs = dict(R0=0.0, tier_weights=[1.0, 10.0], base=base, filter_width=f,
-                  seed=42, active_dims=[0, 1], filter_shift=[1, 0])
+    kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0],
+        base=base,
+        filter_width=f,
+        seed=42,
+        active_dims=[0, 1],
+        filter_shift=[1, 0],
+    )
     env = _make_env("conditional_multiscale", kwargs, ndim=2, height=H)
     rf = env.reward_fn
 
@@ -1344,7 +1399,9 @@ def test_multiscale_filter_shift_moves_blind_strip():
         xs = torch.tensor([[v, v]], dtype=torch.long)
         r = env.reward_fn(xs)[0].item()
         passes_tier0 = (top_digit + 1) % base < f  # 1 == filter_shift[0]
-        assert (r > rf.R0) == passes_tier0, (
+        assert (
+            r > rf.R0
+        ) == passes_tier0, (
             f"top_digit={top_digit}, expected pass_t0={passes_tier0}, got reward={r}"
         )
 
@@ -1352,15 +1409,23 @@ def test_multiscale_filter_shift_moves_blind_strip():
 def test_multiscale_filter_shift_density_invariant():
     """Density (analytic_mode_count) is invariant under filter_shift —
     the shift cyclically rotates the passing window without changing |window|."""
-    base_kwargs = dict(R0=0.0, tier_weights=[1.0, 10.0, 100.0], base=4,
-                       filter_width=3, seed=42, head_seed=2025,
-                       active_dims=list(range(8)),
-                       cross_dim_mods=[None, 3, 3], n_rules=1)
+    base_kwargs = dict(
+        R0=0.0,
+        tier_weights=[1.0, 10.0, 100.0],
+        base=4,
+        filter_width=3,
+        seed=42,
+        head_seed=2025,
+        active_dims=list(range(8)),
+        cross_dim_mods=[None, 3, 3],
+        n_rules=1,
+    )
     counts = []
     for fs0 in range(4):
         kw = dict(base_kwargs, filter_shift=[fs0, 0, 0])
-        env = _make_env("conditional_multiscale", kw, ndim=8, height=64,
-                        validate_modes=False)
+        env = _make_env(
+            "conditional_multiscale", kw, ndim=8, height=64, validate_modes=False
+        )
         counts.append(env.reward_fn.analytic_mode_count())
     assert len(set(counts)) == 1, f"density varies under filter_shift: {counts}"
 
@@ -1373,9 +1438,7 @@ def test_multiscale_filter_shift_density_invariant():
 @pytest.mark.parametrize("n_rules", [1, 16, 64])
 def test_multiscale_K_matched_validate_modes(n_rules):
     p = get_reward_presets("conditional_multiscale", 24, 16)[f"K{n_rules}_matched"]
-    env = _make_env(
-        "conditional_multiscale", p, ndim=24, height=16, validate_modes=True
-    )
+    env = _make_env("conditional_multiscale", p, ndim=24, height=16, validate_modes=True)
     assert env.reward_fn.n_rules == n_rules
     total = env.reward_fn.analytic_mode_count()
     density = total / 16**24
@@ -1399,9 +1462,7 @@ def test_coprime_K_matched_validate_modes(n_rules):
     constructs a witness for trunk LCM=44100. No analytic count; just confirm
     construction + at least one mode exists."""
     p = get_reward_presets("multiplicative_coprime", 10, 64)[f"K{n_rules}_matched"]
-    env = _make_env(
-        "multiplicative_coprime", p, ndim=10, height=64, validate_modes=True
-    )
+    env = _make_env("multiplicative_coprime", p, ndim=10, height=64, validate_modes=True)
     assert env.reward_fn.n_rules == n_rules
 
 


### PR DESCRIPTION
## Summary

- Refactors `ConditionalMultiScale`, `BitwiseXOR`, `MultiplicativeCoprime` to support K-agent specialization via a shared trunk + per-rule head pattern. Selector partitions the trunk-passing mode set into K disjoint per-rule slices; total mode density is invariant in K.
- Adds production K-presets at K=1, 16, 64 with density ~1e-7 (matched to original hypergrid), enabling clean SA-helps-vs-hurts comparisons that control for the mode-sparsity confound.
- Adds `filter_shift` (per-tier cyclic rotation of the blind strip in ConditionalMultiScale) for richer spatial coverage without changing density.
- Replaces the validator's exhaustive trunk-pattern enumeration with a cyclic-uniformity argument when `d_active > 12` (avoids 282B-pattern blowup).

## Class-specific mechanics

- **ConditionalMultiScale**: selector = packed base-f digits mod K; tier-0 filter pass set rotated cyclically by `filter_shift`.
- **BitwiseXOR**: shared `head_A` + per-rule `head_c` chosen by GF(2) witness construction so the combined system is consistent for every rule.
- **MultiplicativeCoprime**: K=64 uses selector-only K-rule (`rule_targets=[None]*K`) since the per-rule LCM-head enum tops at 16 over 4 primes; reaching K=64 with distinct heads would need 6 primes and `h>=169` (T_max prohibitive).

## Test plan

- [x] 102 tests pass in `testing/test_hypergrid.py` (legacy compat, K-rule structural invariants, density invariance, selector coverage, validator behavior, K1=K-trunk equivalence, K-matched production density bounds, filter_shift coverage knob).
- [x] Tutorial notebook (`tutorials/notebooks/hypergrid_rewards.ipynb`) re-executes end-to-end with no errors. New cells visualize K-rule scatter plots at D=2 across K=[1,4,16] for each reward class plus a density-invariance bar chart, all built inline with explicit kwargs (no external config dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
