### PR TITLE
Add baseline filtering and scoring options to ReplayBuffer

### DIFF
--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -77,6 +77,8 @@ class ReplayBuffer:
         async_score: bool = False,
         async_comm: bool = False,
         lazy_sort: bool = False,
+        baseline_filtering: bool = False,
+        scoring_only: bool = False,
     ):
         """Initializes a ReplayBuffer instance.
 
@@ -104,8 +106,15 @@ class ReplayBuffer:
                 to wait for the prior ``isend`` to complete.
             lazy_sort: If True, defer concatenation and sorting until the
                 buffer reaches 2x capacity. Useful for buffer manager ranks
-                that only accumulate data and don't sample every iteration.
-        """
+                that only accumulate data and don't sample every iteration.            baseline_filtering: If True, filter trajectories before sending
+                to the remote buffer manager. Only trajectories with
+                log-reward above the baseline (worst trajectory in the
+                remote buffer) are sent. The baseline is communicated
+                back by the buffer manager in the score response.
+            scoring_only: If True, only send terminating states and
+                log-rewards to the remote buffer manager (not full
+                trajectories). Use when the manager does not store data
+                locally and only needs scoring information."""
         self.env = env
         self.capacity = capacity
         self._is_full = False
@@ -136,6 +145,18 @@ class ReplayBuffer:
         self._pending_batches: list[ContainerUnion] = []
         self._pending_len: int = 0
 
+        # Baseline filtering: skip sending trajectories worse than the
+        # remote buffer's worst item. Updated from score responses.
+        self.baseline_filtering = baseline_filtering
+        self._baseline_log_reward: float = float("-inf")
+        # Filtering counters (tracked when timing=True).
+        self._baseline_total: int = 0
+        self._baseline_kept: int = 0
+        self._baseline_skipped_sends: int = 0
+
+        # Scoring-only: send only terminating states + log_rewards.
+        self.scoring_only = scoring_only
+
     @property
     def device(self) -> torch.device:
         """The device on which the buffer's data is stored.
@@ -156,6 +177,10 @@ class ReplayBuffer:
         call returns None (no pending score yet), and subsequent calls return the
         score from the *previous* submission.  This decouples training throughput
         from buffer scoring latency.
+
+        When ``baseline_filtering`` is enabled, only trajectories with log-reward
+        above the remote buffer's baseline are sent.  If all trajectories in the
+        pending batch are below the baseline, the send is skipped entirely.
 
         Args:
             training_container: The Trajectories, Transitions, or StatesContainer
@@ -191,26 +216,42 @@ class ReplayBuffer:
                         self.timing_data, "wait_pending_score", enabled=self.timing
                     ):
                         stale_score = self._collect_pending_score()
-
-                    with Timer(self.timing_data, "send_objs", enabled=self.timing):
-                        self._isend_and_defer_score(self.pending_container)
-
+                    self._update_baseline(stale_score)
+                    self._filter_and_send(
+                        self.pending_container, self._isend_and_defer_score
+                    )
                     self.pending_container = None
-
                     return stale_score
                 elif self.async_score:
                     # Collect stale score from previous send (if any), then
                     # fire-and-forget the new batch.
                     stale_score = self._collect_pending_score()
-                    with Timer(self.timing_data, "send_objs", enabled=self.timing):
-                        self._send_objs_async(self.pending_container)
+                    self._update_baseline(stale_score)
+                    self._filter_and_send(self.pending_container, self._send_objs_async)
                     self.pending_container = None
                     return stale_score
                 else:
-                    with Timer(self.timing_data, "send_objs", enabled=self.timing):
-                        score = self._send_objs(self.pending_container)
+                    score = self._filter_and_send(
+                        self.pending_container, self._send_objs
+                    )
+                    if score is not None:
+                        self._update_baseline(score)
                     self.pending_container = None
                     return score
+
+    def _filter_and_send(self, container, send_fn):
+        """Filter by baseline, prepare for remote, and send.
+
+        Returns whatever ``send_fn`` returns (a score dict for sync sends,
+        None for async sends), or None if baseline filtering drops everything.
+        """
+        filtered = self._filter_by_baseline(container)
+        if filtered is None:
+            return None
+        with Timer(self.timing_data, "prepare_for_remote", enabled=self.timing):
+            to_send = self._prepare_for_remote(filtered)
+        with Timer(self.timing_data, "send_objs", enabled=self.timing):
+            return send_fn(to_send)
 
     def _send_objs(self, training_container: ContainerUnion) -> dict[str, float]:
         """Sends a training container to the remote manager (synchronous)."""
@@ -235,6 +276,83 @@ class ReplayBuffer:
         score = self._recv_score()
         self._pending_score = False
         return score
+
+    def _update_baseline(self, score_dict: dict[str, float] | None) -> None:
+        """Extract and store the baseline log-reward from a score response.
+
+        Called after receiving a score dict from the buffer manager.
+        Only updates if baseline_filtering is enabled and the score dict
+        contains a ``baseline_log_reward`` key.
+        """
+        if not self.baseline_filtering or score_dict is None:
+            return
+        if "baseline_log_reward" in score_dict:
+            self._baseline_log_reward = score_dict["baseline_log_reward"]
+
+    def _filter_by_baseline(
+        self,
+        container: ContainerUnion,
+    ) -> ContainerUnion | None:
+        """Filter a container to keep only items above the baseline log-reward.
+
+        Returns the filtered container, or None if all items are below the
+        baseline (nothing worth sending).  When baseline_filtering is
+        disabled or no baseline has been set yet, returns the container
+        unchanged.
+        """
+        if not self.baseline_filtering:
+            return container
+        if self._baseline_log_reward == float("-inf"):
+            return container  # No baseline yet — send everything.
+
+        log_rewards = container.log_rewards
+        if log_rewards is None:
+            return container  # Can't filter without rewards.
+
+        mask = log_rewards >= self._baseline_log_reward
+
+        n_total = len(container)
+        n_kept = int(mask.sum().item())
+        if self.timing:
+            self._baseline_total += n_total
+            self._baseline_kept += n_kept
+
+        if mask.all():
+            return container  # All above baseline — send everything.
+        if not mask.any():
+            if self.timing:
+                self._baseline_skipped_sends += 1
+            return None  # All below baseline — skip send.
+
+        indices = torch.where(mask)[0]
+        return container[indices]
+
+    def _prepare_for_remote(self, container: ContainerUnion) -> ContainerUnion:
+        """Convert a container to a lightweight form for remote scoring.
+
+        When ``scoring_only`` is True, extracts only the terminating states
+        and log-rewards into a ``StatesContainer``, discarding full
+        trajectory data (intermediate states, actions, etc.) to reduce
+        serialization and communication cost.
+
+        When ``scoring_only`` is False, returns the container unchanged.
+        """
+        if not self.scoring_only:
+            return container
+        if isinstance(container, StatesContainer):
+            return container
+
+        terminating_states = container.terminating_states
+        log_rewards = container.log_rewards
+        n = len(terminating_states)
+        return StatesContainer(
+            env=self.env,
+            states=terminating_states,
+            is_terminating=torch.ones(
+                n, dtype=torch.bool, device=terminating_states.device
+            ),
+            log_rewards=log_rewards,
+        )
 
     def _isend_and_defer_score(self, training_container: ContainerUnion) -> None:
         """Non-blocking send (isend), deferred score: fire-and-forget data, collect score on next add().
@@ -555,6 +673,15 @@ class ReplayBuffer:
             if total_time > 0:
                 bw = (total_bytes / 1e6) / total_time
                 log_str += f"  effective_send_bandwidth: {bw:.1f} MB/s\n"
+        # Baseline filtering stats.
+        if self._baseline_total > 0:
+            pct_filtered = 100.0 * (1.0 - self._baseline_kept / self._baseline_total)
+            log_str += (
+                f"  baseline_filtering: {self._baseline_kept}/{self._baseline_total} "
+                f"kept ({pct_filtered:.1f}% filtered), "
+                f"{self._baseline_skipped_sends} sends skipped entirely\n"
+            )
+
         return log_str
 
 

--- a/src/gfn/containers/replay_buffer.py
+++ b/src/gfn/containers/replay_buffer.py
@@ -79,6 +79,7 @@ class ReplayBuffer:
         lazy_sort: bool = False,
         baseline_filtering: bool = False,
         scoring_only: bool = False,
+        baseline_refresh_after: int = 10,
     ):
         """Initializes a ReplayBuffer instance.
 
@@ -106,15 +107,20 @@ class ReplayBuffer:
                 to wait for the prior ``isend`` to complete.
             lazy_sort: If True, defer concatenation and sorting until the
                 buffer reaches 2x capacity. Useful for buffer manager ranks
-                that only accumulate data and don't sample every iteration.            baseline_filtering: If True, filter trajectories before sending
-                to the remote buffer manager. Only trajectories with
-                log-reward above the baseline (worst trajectory in the
-                remote buffer) are sent. The baseline is communicated
-                back by the buffer manager in the score response.
-            scoring_only: If True, only send terminating states and
-                log-rewards to the remote buffer manager (not full
-                trajectories). Use when the manager does not store data
-                locally and only needs scoring information."""
+                that only accumulate data and don't sample every iteration.
+            baseline_filtering: If True, only send containers whose
+                ``log_rewards`` exceed the baseline reported by the remote
+                manager. Requires ``remote_manager_rank`` and a
+                ``Trajectories`` or ``StatesContainer`` payload;
+                ``Transitions`` is rejected.
+            scoring_only: If True, convert payloads to a lightweight
+                ``StatesContainer`` (terminating states + log-rewards) before
+                sending. Local storage is unaffected.
+            baseline_refresh_after: When ``baseline_filtering`` is enabled,
+                bypass the filter on the next send after this many
+                consecutive fully-filtered batches so the baseline can
+                refresh.
+        """
         self.env = env
         self.capacity = capacity
         self._is_full = False
@@ -145,11 +151,18 @@ class ReplayBuffer:
         self._pending_batches: list[ContainerUnion] = []
         self._pending_len: int = 0
 
-        # Baseline filtering: skip sending trajectories worse than the
-        # remote buffer's worst item. Updated from score responses.
+        # Baseline filtering: skip sending containers worse than the
+        # baseline reported by the remote manager. Updated from score
+        # responses; bypasses itself after `baseline_refresh_after`
+        # consecutive fully-filtered batches so the baseline can refresh.
+        if baseline_filtering and remote_manager_rank is None:
+            raise ValueError(
+                "baseline_filtering=True requires remote_manager_rank to be set."
+            )
         self.baseline_filtering = baseline_filtering
+        self.baseline_refresh_after = baseline_refresh_after
         self._baseline_log_reward: float = float("-inf")
-        # Filtering counters (tracked when timing=True).
+        self._consecutive_filtered_empty: int = 0
         self._baseline_total: int = 0
         self._baseline_kept: int = 0
         self._baseline_skipped_sends: int = 0
@@ -293,58 +306,77 @@ class ReplayBuffer:
         self,
         container: ContainerUnion,
     ) -> ContainerUnion | None:
-        """Filter a container to keep only items above the baseline log-reward.
+        """Filter a container to keep only items with log_reward >= baseline.
 
-        Returns the filtered container, or None if all items are below the
-        baseline (nothing worth sending).  When baseline_filtering is
-        disabled or no baseline has been set yet, returns the container
-        unchanged.
+        Returns the (possibly subset) container, or None if every item is
+        below the baseline.  After ``baseline_refresh_after`` consecutive
+        fully-filtered batches, the next batch bypasses the filter so the
+        worker can receive a fresh baseline.  ``Transitions`` is not
+        supported (its log_rewards is per-transition with ``-inf`` for
+        non-terminating rows, so per-row filtering would break DB/SubTB).
         """
         if not self.baseline_filtering:
             return container
+        assert isinstance(container, (Trajectories, StatesContainer)), (
+            "baseline_filtering supports Trajectories or StatesContainer only; "
+            f"got {type(container).__name__}"
+        )
         if self._baseline_log_reward == float("-inf"):
             return container  # No baseline yet — send everything.
 
         log_rewards = container.log_rewards
         if log_rewards is None:
-            return container  # Can't filter without rewards.
-
-        mask = log_rewards >= self._baseline_log_reward
+            return container  # e.g. backward trajectories — nothing to filter on.
 
         n_total = len(container)
+        assert log_rewards.shape == (
+            n_total,
+        ), f"log_rewards shape {tuple(log_rewards.shape)} must equal ({n_total},)"
+        mask = log_rewards >= self._baseline_log_reward
         n_kept = int(mask.sum().item())
-        if self.timing:
-            self._baseline_total += n_total
-            self._baseline_kept += n_kept
+        self._baseline_total += n_total
+        self._baseline_kept += n_kept
 
         if mask.all():
-            return container  # All above baseline — send everything.
+            self._consecutive_filtered_empty = 0
+            return container
         if not mask.any():
-            if self.timing:
-                self._baseline_skipped_sends += 1
-            return None  # All below baseline — skip send.
+            self._baseline_skipped_sends += 1
+            self._consecutive_filtered_empty += 1
+            if self._consecutive_filtered_empty >= self.baseline_refresh_after:
+                self._consecutive_filtered_empty = 0
+                return container  # Force a send to refresh the baseline.
+            return None
 
+        self._consecutive_filtered_empty = 0
         indices = torch.where(mask)[0]
         return container[indices]
 
     def _prepare_for_remote(self, container: ContainerUnion) -> ContainerUnion:
         """Convert a container to a lightweight form for remote scoring.
 
-        When ``scoring_only`` is True, extracts only the terminating states
-        and log-rewards into a ``StatesContainer``, discarding full
-        trajectory data (intermediate states, actions, etc.) to reduce
-        serialization and communication cost.
-
+        When ``scoring_only`` is True, extracts terminating states and
+        log-rewards into a ``StatesContainer``.  ``Transitions`` is
+        rejected because its ``log_rewards`` shape does not match
+        ``terminating_states`` (it is per-transition, not per-trajectory).
         When ``scoring_only`` is False, returns the container unchanged.
         """
         if not self.scoring_only:
             return container
         if isinstance(container, StatesContainer):
             return container
+        assert isinstance(container, Trajectories), (
+            "scoring_only supports Trajectories or StatesContainer only; "
+            f"got {type(container).__name__}"
+        )
 
         terminating_states = container.terminating_states
         log_rewards = container.log_rewards
         n = len(terminating_states)
+        assert log_rewards is not None and log_rewards.shape == (n,), (
+            "Trajectories must have log_rewards of shape (batch_size,) for "
+            "scoring_only; backward trajectories are not supported."
+        )
         return StatesContainer(
             env=self.env,
             states=terminating_states,
@@ -716,6 +748,9 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
         async_score: bool = False,
         async_comm: bool = False,
         lazy_sort: bool = False,
+        baseline_filtering: bool = False,
+        scoring_only: bool = False,
+        baseline_refresh_after: int = 10,
     ):
         """Initializes a NormBasedDiversePrioritizedReplayBuffer instance.
 
@@ -735,6 +770,9 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
                 are collected lazily on the next add() call.
             async_comm: If True, fully non-blocking send and recv.
             lazy_sort: If True, defer concatenation and sorting until 2x capacity.
+            baseline_filtering: See :class:`ReplayBuffer`.
+            scoring_only: See :class:`ReplayBuffer`.
+            baseline_refresh_after: See :class:`ReplayBuffer`.
         """
         super().__init__(
             env,
@@ -747,6 +785,9 @@ class NormBasedDiversePrioritizedReplayBuffer(ReplayBuffer):
             async_score=async_score,
             async_comm=async_comm,
             lazy_sort=lazy_sort,
+            baseline_filtering=baseline_filtering,
+            scoring_only=scoring_only,
+            baseline_refresh_after=baseline_refresh_after,
         )
         self.cutoff_distance = cutoff_distance
         self.p_norm_distance = p_norm_distance

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -2,6 +2,8 @@ import math
 from collections import defaultdict
 from typing import Callable, Optional
 
+import torch
+
 from gfn.containers.message import Message, MessageType
 from gfn.containers.replay_buffer import (
     NormBasedDiversePrioritizedReplayBuffer,
@@ -20,6 +22,20 @@ METADATA_TAG = 1
 
 
 class ReplayBufferManager:
+    """Receives training containers on the manager rank and replies with scores.
+
+    The manager optionally stores incoming data in a local replay buffer
+    (``store_locally=True``) and injects a ``baseline_log_reward`` into every
+    score response so workers with ``baseline_filtering`` can skip sending
+    payloads that would be immediately evicted.  The baseline source is
+    controlled by ``baseline_strategy``:
+
+    - ``"min"`` / ``"percentile"`` read from the local buffer once it
+      reaches capacity.
+    - ``"ema"`` (and any strategy when the buffer is unavailable, e.g.
+      ``store_locally=False``) reads from a running EMA of incoming
+      batch minima.
+    """
 
     def __init__(
         self,
@@ -33,8 +49,20 @@ class ReplayBufferManager:
         communication_backend: str = "mpi",
         timing: bool = False,
         store_locally: bool = True,
+        baseline_strategy: str = "min",
+        baseline_percentile: float = 0.1,
+        baseline_ema_alpha: float = 0.1,
     ):
+        if baseline_strategy not in ("min", "percentile", "ema"):
+            raise ValueError(
+                "baseline_strategy must be one of 'min', 'percentile', 'ema'; "
+                f"got {baseline_strategy!r}"
+            )
         self.store_locally = store_locally
+        self.baseline_strategy = baseline_strategy
+        self.baseline_percentile = baseline_percentile
+        self.baseline_ema_alpha = baseline_ema_alpha
+        self._baseline_ema: float | None = None
         self.rank = rank
         self.is_running = True
         self.exit_counter = 0
@@ -73,24 +101,50 @@ class ReplayBufferManager:
         """Default score function if none provided, placeholder."""
         return {"score": math.inf}
 
-    def _inject_baseline_log_reward(self, score_dict: dict[str, float]) -> None:
-        """Add ``baseline_log_reward`` to *score_dict* when the buffer is full.
+    def _inject_baseline_log_reward(
+        self, score_dict: dict[str, float], incoming
+    ) -> None:
+        """Inject ``baseline_log_reward`` into *score_dict* per ``baseline_strategy``.
 
-        Reports the worst (min) log-reward currently held in the replay
-        buffer so that agents with ``baseline_filtering=True`` can skip
-        sending trajectories that would be immediately evicted.
-
-        The key is only added once the buffer has reached capacity;
-        before that every trajectory is accepted anyway.
+        Updates the EMA tracker from ``incoming.log_rewards`` (used as the
+        source under ``"ema"`` and as a fallback when the local buffer is
+        unavailable), then picks a baseline from the buffer (``"min"`` /
+        ``"percentile"`` once at capacity) or the EMA.  Non-finite rewards
+        are excluded so containers with ``-inf`` (e.g. Transitions) do not
+        poison the statistics.
         """
+        incoming_lr = getattr(incoming, "log_rewards", None)
+        if incoming_lr is not None and incoming_lr.numel() > 0:
+            finite = incoming_lr[torch.isfinite(incoming_lr)]
+            if finite.numel() > 0:
+                batch_min = float(finite.min().item())
+                a = self.baseline_ema_alpha
+                self._baseline_ema = (
+                    batch_min
+                    if self._baseline_ema is None
+                    else a * batch_min + (1 - a) * self._baseline_ema
+                )
+
+        buf = self.replay_buffer
+        tc = buf.training_container
         if (
-            self.replay_buffer is not None
-            and self.replay_buffer.training_container is not None
-            and len(self.replay_buffer) >= self.capacity
+            self.store_locally
+            and self.baseline_strategy in ("min", "percentile")
+            and tc is not None
+            and tc.log_rewards is not None
+            and len(buf) >= self.capacity
         ):
-            buf_log_rewards = self.replay_buffer.training_container.log_rewards
-            if buf_log_rewards is not None and buf_log_rewards.numel() > 0:
-                score_dict["baseline_log_reward"] = float(buf_log_rewards.min().item())
+            finite_lr = tc.log_rewards[torch.isfinite(tc.log_rewards)]
+            if finite_lr.numel() > 0:
+                if self.baseline_strategy == "min":
+                    score_dict["baseline_log_reward"] = float(finite_lr.min().item())
+                else:  # "percentile"
+                    score_dict["baseline_log_reward"] = float(
+                        finite_lr.quantile(self.baseline_percentile).item()
+                    )
+                return
+        if self._baseline_ema is not None:
+            score_dict["baseline_log_reward"] = self._baseline_ema
 
     def _compute_metadata(self) -> dict:
         raise NotImplementedError(
@@ -128,7 +182,7 @@ class ReplayBufferManager:
                 score_dict = self.scoring_function(
                     msg.message_data, sender_rank=sender_rank
                 )
-            self._inject_baseline_log_reward(score_dict)
+            self._inject_baseline_log_reward(score_dict, msg.message_data)
             with Timer(self._timing_data, "send", enabled=self.timing):
                 message = Message(message_type=MessageType.DATA, message_data=score_dict)
                 message_tensor = message.serialize()
@@ -190,7 +244,7 @@ class ReplayBufferManager:
                 score_dict = self.scoring_function(
                     msg.message_data, sender_rank=sender_rank
                 )
-            self._inject_baseline_log_reward(score_dict)
+            self._inject_baseline_log_reward(score_dict, msg.message_data)
             with Timer(self._timing_data, "send", enabled=self.timing):
                 message = Message(message_type=MessageType.DATA, message_data=score_dict)
                 message_tensor = message.serialize()

--- a/src/gfn/containers/replay_buffer_manager.py
+++ b/src/gfn/containers/replay_buffer_manager.py
@@ -32,7 +32,9 @@ class ReplayBufferManager:
         remote_manager_rank: int | None = None,
         communication_backend: str = "mpi",
         timing: bool = False,
+        store_locally: bool = True,
     ):
+        self.store_locally = store_locally
         self.rank = rank
         self.is_running = True
         self.exit_counter = 0
@@ -71,6 +73,25 @@ class ReplayBufferManager:
         """Default score function if none provided, placeholder."""
         return {"score": math.inf}
 
+    def _inject_baseline_log_reward(self, score_dict: dict[str, float]) -> None:
+        """Add ``baseline_log_reward`` to *score_dict* when the buffer is full.
+
+        Reports the worst (min) log-reward currently held in the replay
+        buffer so that agents with ``baseline_filtering=True`` can skip
+        sending trajectories that would be immediately evicted.
+
+        The key is only added once the buffer has reached capacity;
+        before that every trajectory is accepted anyway.
+        """
+        if (
+            self.replay_buffer is not None
+            and self.replay_buffer.training_container is not None
+            and len(self.replay_buffer) >= self.capacity
+        ):
+            buf_log_rewards = self.replay_buffer.training_container.log_rewards
+            if buf_log_rewards is not None and buf_log_rewards.numel() > 0:
+                score_dict["baseline_log_reward"] = float(buf_log_rewards.min().item())
+
     def _compute_metadata(self) -> dict:
         raise NotImplementedError(
             "_compute_metadata is not implemented for default replay buffer manager"
@@ -100,12 +121,14 @@ class ReplayBufferManager:
         self._prune_completed_sends()
 
         if msg.message_type == MessageType.DATA:
-            with Timer(self._timing_data, "replay_add", enabled=self.timing):
-                self.replay_buffer.add(msg.message_data)
+            if self.store_locally:
+                with Timer(self._timing_data, "replay_add", enabled=self.timing):
+                    self.replay_buffer.add(msg.message_data)
             with Timer(self._timing_data, "scoring", enabled=self.timing):
                 score_dict = self.scoring_function(
                     msg.message_data, sender_rank=sender_rank
                 )
+            self._inject_baseline_log_reward(score_dict)
             with Timer(self._timing_data, "send", enabled=self.timing):
                 message = Message(message_type=MessageType.DATA, message_data=score_dict)
                 message_tensor = message.serialize()
@@ -160,12 +183,14 @@ class ReplayBufferManager:
         is in flight, making it preferable when all ranks share a CPU.
         """
         if msg.message_type == MessageType.DATA:
-            with Timer(self._timing_data, "replay_add", enabled=self.timing):
-                self.replay_buffer.add(msg.message_data)
+            if self.store_locally:
+                with Timer(self._timing_data, "replay_add", enabled=self.timing):
+                    self.replay_buffer.add(msg.message_data)
             with Timer(self._timing_data, "scoring", enabled=self.timing):
                 score_dict = self.scoring_function(
                     msg.message_data, sender_rank=sender_rank
                 )
+            self._inject_baseline_log_reward(score_dict)
             with Timer(self._timing_data, "send", enabled=self.timing):
                 message = Message(message_type=MessageType.DATA, message_data=score_dict)
                 message_tensor = message.serialize()

--- a/testing/test_replay_buffer.py
+++ b/testing/test_replay_buffer.py
@@ -7,6 +7,7 @@ from gfn.containers.replay_buffer import (
     NormBasedDiversePrioritizedReplayBuffer,
     ReplayBuffer,
 )
+from gfn.containers.replay_buffer_manager import ReplayBufferManager
 from gfn.containers.states_container import StatesContainer
 from gfn.containers.trajectories import Trajectories
 from gfn.containers.transitions import Transitions
@@ -626,3 +627,158 @@ def test_diversity_repr_shape():
         states_with_cond
     )
     assert repr_with_cond.shape == (2, 3)  # 2 state dims + 1 condition dim
+
+
+# --- baseline_filtering / scoring_only / store_locally --- #
+
+
+def test_baseline_filtering_requires_remote_rank(simple_env):
+    with pytest.raises(ValueError, match="baseline_filtering=True requires"):
+        ReplayBuffer(simple_env, baseline_filtering=True)
+
+
+def test_filter_by_baseline_no_baseline_yet(simple_env, trajectories):
+    buf = ReplayBuffer(simple_env, baseline_filtering=True, remote_manager_rank=0)
+    assert buf._filter_by_baseline(trajectories) is trajectories
+
+
+def test_filter_by_baseline_all_above(simple_env, trajectories):
+    buf = ReplayBuffer(simple_env, baseline_filtering=True, remote_manager_rank=0)
+    buf._baseline_log_reward = -1.0
+    assert buf._filter_by_baseline(trajectories) is trajectories
+    assert buf._consecutive_filtered_empty == 0
+
+
+def test_filter_by_baseline_all_below(simple_env, trajectories):
+    buf = ReplayBuffer(simple_env, baseline_filtering=True, remote_manager_rank=0)
+    buf._baseline_log_reward = 100.0
+    assert buf._filter_by_baseline(trajectories) is None
+    assert buf._baseline_skipped_sends == 1
+    assert buf._consecutive_filtered_empty == 1
+
+
+def test_filter_by_baseline_partial(simple_env, trajectories):
+    buf = ReplayBuffer(simple_env, baseline_filtering=True, remote_manager_rank=0)
+    buf._baseline_log_reward = 2.0
+    out = buf._filter_by_baseline(trajectories)
+    assert out is not None
+    assert len(out) == 3
+    assert out.log_rewards is not None
+    assert torch.equal(out.log_rewards, torch.tensor([2.0, 3.0, 4.0]))
+
+
+def test_filter_by_baseline_force_refresh(simple_env, trajectories):
+    buf = ReplayBuffer(
+        simple_env,
+        baseline_filtering=True,
+        remote_manager_rank=0,
+        baseline_refresh_after=2,
+    )
+    buf._baseline_log_reward = 100.0
+    assert buf._filter_by_baseline(trajectories) is None
+    # Second consecutive empty hits the threshold and bypasses the filter.
+    assert buf._filter_by_baseline(trajectories) is trajectories
+    assert buf._consecutive_filtered_empty == 0
+
+
+def test_filter_by_baseline_rejects_transitions(simple_env, transitions):
+    buf = ReplayBuffer(simple_env, baseline_filtering=True, remote_manager_rank=0)
+    buf._baseline_log_reward = 0.0
+    with pytest.raises(AssertionError, match="Trajectories or StatesContainer"):
+        buf._filter_by_baseline(transitions)
+
+
+def test_prepare_for_remote_trajectories(simple_env, trajectories):
+    buf = ReplayBuffer(simple_env, scoring_only=True, remote_manager_rank=0)
+    out = buf._prepare_for_remote(trajectories)
+    assert isinstance(out, StatesContainer)
+    assert bool(out.is_terminating.all())
+    assert out.log_rewards is not None
+    assert trajectories.log_rewards is not None
+    assert torch.equal(out.log_rewards, trajectories.log_rewards)
+
+
+def test_prepare_for_remote_states_container_noop(simple_env, state_pairs):
+    buf = ReplayBuffer(simple_env, scoring_only=True, remote_manager_rank=0)
+    assert buf._prepare_for_remote(state_pairs) is state_pairs
+
+
+def test_prepare_for_remote_rejects_transitions(simple_env, transitions):
+    buf = ReplayBuffer(simple_env, scoring_only=True, remote_manager_rank=0)
+    with pytest.raises(AssertionError, match="Trajectories or StatesContainer"):
+        buf._prepare_for_remote(transitions)
+
+
+# --- ReplayBufferManager baseline injection --- #
+
+
+def test_manager_baseline_strategy_validation(simple_env):
+    with pytest.raises(ValueError, match="baseline_strategy must be"):
+        ReplayBufferManager(
+            simple_env, rank=0, num_training_ranks=1, baseline_strategy="bad"
+        )
+
+
+def test_manager_baseline_min_when_buffer_full(simple_env, trajectories):
+    mgr = ReplayBufferManager(
+        simple_env,
+        rank=0,
+        num_training_ranks=1,
+        capacity=5,
+        baseline_strategy="min",
+    )
+    mgr.replay_buffer.add(trajectories)
+    mgr.replay_buffer._flush_pending()  # commit lazy-sorted data.
+    score: dict = {"score": 0.0}
+    mgr._inject_baseline_log_reward(score, None)  # no EMA influence.
+    assert score["baseline_log_reward"] == pytest.approx(0.0)
+
+
+def test_manager_baseline_percentile(simple_env, trajectories):
+    mgr = ReplayBufferManager(
+        simple_env,
+        rank=0,
+        num_training_ranks=1,
+        capacity=5,
+        baseline_strategy="percentile",
+        baseline_percentile=0.5,
+    )
+    mgr.replay_buffer.add(trajectories)
+    mgr.replay_buffer._flush_pending()
+    score: dict = {"score": 0.0}
+    mgr._inject_baseline_log_reward(score, None)
+    assert score["baseline_log_reward"] == pytest.approx(2.0)  # median of [0..4]
+
+
+def test_manager_baseline_ema_fallback_when_not_storing(simple_env, trajectories):
+    mgr = ReplayBufferManager(
+        simple_env,
+        rank=0,
+        num_training_ranks=1,
+        capacity=5,
+        store_locally=False,
+    )
+    score: dict = {"score": 0.0}
+    mgr._inject_baseline_log_reward(score, trajectories)
+    # EMA initialised from this batch's min finite reward == 0.0.
+    assert score["baseline_log_reward"] == pytest.approx(0.0)
+
+
+def test_manager_baseline_ema_skips_non_finite(simple_env, trajectories):
+    # -inf entries (e.g. from Transitions' non-terminating rows) must not
+    # poison the EMA.
+    mgr = ReplayBufferManager(
+        simple_env,
+        rank=0,
+        num_training_ranks=1,
+        capacity=5,
+        store_locally=False,
+        baseline_strategy="ema",
+    )
+    trajectories._log_rewards = torch.tensor(
+        [float("-inf"), 1.0, 2.0, 3.0, 4.0], dtype=torch.get_default_dtype()
+    )
+    score: dict = {"score": 0.0}
+    mgr._inject_baseline_log_reward(score, trajectories)
+    # Min over finite values is 1.0; the -inf must be filtered out.
+    assert score["baseline_log_reward"] == pytest.approx(1.0)


### PR DESCRIPTION
- [x] I've read the [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file
- [x] My code follows the typing guidelines
- [ ] I've added appropriate tests
- [x] I've run pre-commit hooks locally

## Description
### TLDR
- Added baseline_filtering to send only trajectories whose log-reward exceeds the current remote buffer baseline.
- Added scoring_only mode to send only terminating states and log-rewards instead of full trajectory data when trajectory storage is unnecessary.


### More Details
This pull request introduces two major new features to the replay buffer system: baseline filtering and scoring-only communication. These changes allow agents to avoid sending low-value trajectories and to reduce communication costs by sending only essential data when appropriate. The buffer manager now also supports operation without local storage, and tracks/reporting for these new modes has been added.

**Replay Buffer Improvements:**

* Added `baseline_filtering` option to `ReplayBuffer` to filter out trajectories with log-reward below the current baseline (worst item in the remote buffer); includes logic for updating and applying the baseline, and tracking statistics on filtered/skipped sends. [[1]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR80-R81) [[2]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aL107-R117) [[3]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR148-R159) [[4]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR181-R184) [[5]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aL194-R255) [[6]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR280-R356) [[7]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR676-R684)
* Added `scoring_only` option to `ReplayBuffer`, allowing agents to send only terminating states and log-rewards (not full trajectories) to the remote buffer manager, reducing communication and serialization overhead. [[1]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR80-R81) [[2]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aL107-R117) [[3]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR148-R159) [[4]](diffhunk://#diff-34d32d1df13b0243e92f09447b23b3ef52cba940af4ac1e399585b9bd210721aR280-R356)

**Replay Buffer Manager Enhancements:**

* Added `store_locally` option to `ReplayBufferManager` to allow operation without storing data locally; data is only scored and not retained if this is set to `False`. [[1]](diffhunk://#diff-71e4ad6e858554524fc404374539841fde0d96bd2a094af2ba7d215d89b96facR35-R37) [[2]](diffhunk://#diff-71e4ad6e858554524fc404374539841fde0d96bd2a094af2ba7d215d89b96facR124-R131) [[3]](diffhunk://#diff-71e4ad6e858554524fc404374539841fde0d96bd2a094af2ba7d215d89b96facR186-R193)
* Buffer manager now injects a `baseline_log_reward` field into score responses (when full) to communicate the current baseline to agents using baseline filtering. [[1]](diffhunk://#diff-71e4ad6e858554524fc404374539841fde0d96bd2a094af2ba7d215d89b96facR76-R94) [[2]](diffhunk://#diff-71e4ad6e858554524fc404374539841fde0d96bd2a094af2ba7d215d89b96facR124-R131) [[3]](diffhunk://#diff-71e4ad6e858554524fc404374539841fde0d96bd2a094af2ba7d215d89b96facR186-R193)

**Monitoring and Logging:**

* Enhanced timing logs in `ReplayBuffer` to report statistics on baseline filtering: proportion of items kept/filtered and number of sends skipped due to filtering.