### PR TITLE
Teacher-forced (parallel) TB loss recompute for recurrent estimators

### DIFF
--- a/src/gfn/estimators.py
+++ b/src/gfn/estimators.py
@@ -1239,19 +1239,23 @@ class RecurrentDiscretePolicyEstimator(RecurrentPolicyMixin, DiscretePolicyEstim
     per-step artifacts. Non-recurrent estimators should use the default PolicyMixin
     and the standard ``DiscretePolicyEstimator`` base class instead.
 
-    An optional, fixed-length-only performance mode (opt-in; the default leaves
+    Two optional, fixed-length-only performance modes (both opt-in; defaults leave
     behavior unchanged):
 
     - ``use_kv_cache=True`` decodes one token per step against a persistent, in-place
       preallocated KV-cache, cutting rollout cost from O(L^3) to O(L^2). The in-place
       buffers cannot carry gradients, so cached sampling runs under ``no_grad`` -- it is
       a sampling-time optimization, ideal for inference/rollout.
+    - ``teacher_forced_loss=True`` recomputes PF log-probs in the loss with a single
+      parallel forward per trajectory (grad-bearing). It is auto-enabled by
+      ``use_kv_cache`` so a cached policy stays trainable via
+      ``loss(..., recalculate_all_logprobs=True)``.
 
     Notes
     -----
     - ``init_carry`` is a hard requirement for compatibility with the recurrent
       PolicyMixin.
-    - The cached fast path assumes fixed-length trajectories; see the Gap-2 TODO in
+    - Both performance modes assume fixed-length trajectories; see the Gap-2 TODO in
       ``gfn/utils/prob_calculations.py``.
 
     Attributes:
@@ -1271,11 +1275,12 @@ class RecurrentDiscretePolicyEstimator(RecurrentPolicyMixin, DiscretePolicyEstim
         debug: bool = False,
         use_kv_cache: bool = False,
         cache_max_len: int | None = None,
+        teacher_forced_loss: bool = False,
     ):
         """Initializes a RecurrentDiscretePolicyEstimator.
 
-        See the class docstring for what ``use_kv_cache`` does and why cached sampling
-        is ``no_grad``.
+        See the class docstring for what the two performance modes do and why cached
+        sampling is ``no_grad``.
 
         Args:
             module: The neural network module to use.
@@ -1284,12 +1289,15 @@ class RecurrentDiscretePolicyEstimator(RecurrentPolicyMixin, DiscretePolicyEstim
             is_backward: Flag indicating whether this estimator is for backward policy.
             debug: If True, enables expensive validation checks.
             use_kv_cache: Opt into the O(L^2) in-place KV-cache sampling fast path.
-                Cached sampling runs under ``no_grad``, so it is a sampling-time
-                optimization (ideal for inference/rollout). If False (default), sampling
-                uses the corrected grad-bearing full-prefix forward each step.
+                Sampling then runs under ``no_grad``, so ``teacher_forced_loss`` is
+                enabled automatically to keep the policy trainable. If False (default),
+                sampling uses the corrected grad-bearing full-prefix forward each step.
             cache_max_len: KV-cache preallocation length; defaults to the module's
                 ``max_position_embeddings``. Rarely set by hand; must be at least the
                 env horizon + 1 (the +1 is the BOS token).
+            teacher_forced_loss: Recompute PF log-probs in the loss with one parallel
+                forward per trajectory instead of the per-step loop. Auto-enabled by
+                ``use_kv_cache``. Fixed-length trajectories only.
         """
         if preprocessor is None:
             preprocessor = IdentityPreprocessor(output_dim=None)
@@ -1321,6 +1329,9 @@ class RecurrentDiscretePolicyEstimator(RecurrentPolicyMixin, DiscretePolicyEstim
                 f"max_position_embeddings ({max_positions})."
             )
         self._cache_max_len = cache_max_len
+        # Cached sampling is no_grad, so training needs a grad-bearing loss recompute;
+        # auto-enable teacher forcing (it is inert for sampling-only / inference use).
+        self.teacher_forced_loss = teacher_forced_loss or use_kv_cache
 
     @property
     def _bos_index(self) -> int:

--- a/src/gfn/utils/prob_calculations.py
+++ b/src/gfn/utils/prob_calculations.py
@@ -6,6 +6,7 @@ from gfn.containers import Trajectories, Transitions
 from gfn.estimators import (
     Estimator,
     PolicyEstimatorProtocol,
+    RecurrentDiscretePolicyEstimator,
     RecurrentPolicyMixin,
     validate_policy_estimator,
 )
@@ -53,6 +54,93 @@ def get_trajectory_pfs_and_pbs(
     return log_pf_trajectories, log_pb_trajectories
 
 
+def _pf_valid_masks(
+    trajectories: Trajectories,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Masks selecting the valid PF steps: non-sink states and non-dummy actions.
+
+    Returns ``(state_mask (T+1, N), action_mask (T, N))``; boolean indexing with these
+    flattens the batch row-major, which is how the vectorized/teacher-forced paths line
+    logits up with actions.
+    """
+    state_mask = ~trajectories.states.is_sink_state
+    action_mask = ~trajectories.actions.is_dummy
+    assert (
+        state_mask[:-1] == action_mask
+    ).all(), "state/action mask misalignment in PF evaluation"
+    return state_mask, action_mask
+
+
+def _scatter_pf(action_mask: torch.Tensor, valid_log_pf: torch.Tensor) -> torch.Tensor:
+    """Scatter per-step log-probs back into a dense ``(T, N)`` tensor (0 where masked)."""
+    out = torch.full(
+        action_mask.shape,
+        0.0,
+        dtype=torch.get_default_dtype(),
+        device=valid_log_pf.device,
+    )
+    out[action_mask] = valid_log_pf.to(out.dtype)
+    return out
+
+
+def _recurrent_teacher_forced_pfs(
+    policy_pf: Any,  # a RecurrentDiscretePolicyEstimator (Any avoids protected-access noise)
+    trajectories: Trajectories,
+    **policy_kwargs: Any,
+) -> torch.Tensor:
+    """Teacher-forced (parallel) PF log-probs for a recurrent estimator.
+
+    Instead of the per-step recompute (which re-runs the sequence model once per
+    timestep, re-paying the sequential rollout cost inside the loss), this runs a
+    **single** causal forward over the whole committed trajectory
+    ``[BOS, w_0, ..., w_{L-1}]`` and gathers the per-step action log-probs. Because
+    the sequence model's parallel forward is equal to its incremental decode
+    (proven by the module tests), the result matches the per-step path to numerical
+    tolerance — but with one grad-bearing forward and a shallow autograd graph.
+
+    Only **fixed-length** trajectories are supported (every trajectory terminates at
+    the same step); variable-length teacher forcing is out of scope (Gap 2).
+
+    Args:
+        policy_pf: The recurrent forward policy estimator.
+        trajectories: Forward trajectories to score.
+        **policy_kwargs: Forwarded to ``to_probability_distribution``.
+
+    Returns:
+        ``log_pf`` of shape ``(T, N)``.
+    """
+    T = trajectories.max_length
+    N = trajectories.batch_size
+
+    # Fixed-length guard: a sink state may appear only at the final state index.
+    if bool(trajectories.states.is_sink_state[:-1].any()):
+        raise NotImplementedError(
+            "Teacher-forced recompute (teacher_forced_loss=True) supports only "
+            "fixed-length trajectories; got variable-length trajectories. See the "
+            "Gap-2 TODO in this module for the variable-length follow-up."
+        )
+
+    # Reuse the estimator's own full-prefix forward so the teacher-forcing input is
+    # built identically to sampling (same [BOS, w_0, ...] construction) rather than
+    # re-derived here. The last committed state (index -2; -1 is the sink) holds the
+    # whole word sequence, and _forward_full_prefix returns the full-sequence logits.
+    terminal = trajectories.states[-2]
+    tokens = terminal.tensor.long()
+    lengths = (terminal.tensor >= 0).sum(dim=-1)
+    logits, _ = policy_pf._forward_full_prefix(tokens, lengths)  # (N, T, n_actions)
+    # Transpose (N, T, ·) -> (T, N, ·) then row-major flatten, matching the flattened
+    # valid states/actions below (which also flatten (T, N) row-major).
+    logits = logits.transpose(0, 1).reshape(T * N, -1)
+
+    state_mask, action_mask = _pf_valid_masks(trajectories)
+    valid_states = trajectories.states[state_mask]
+    valid_actions = trajectories.actions[action_mask]
+
+    dist = policy_pf.to_probability_distribution(valid_states, logits, **policy_kwargs)
+    valid_log_pf = dist.log_prob(valid_actions.tensor)  # (T*N,)
+    return _scatter_pf(action_mask, valid_log_pf)
+
+
 def get_trajectory_pfs(
     pf: Estimator,
     trajectories: Trajectories,
@@ -88,6 +176,16 @@ def get_trajectory_pfs(
     if trajectories.has_log_probs and not recalculate_all_logprobs:
         log_pf_trajectories = trajectories.log_probs
         assert log_pf_trajectories is not None
+        # Guard the KV-cache footgun: cached sampling runs under no_grad, so its saved
+        # log-probs are detached. Reusing them under an active graph would make
+        # loss.backward() fail with an opaque autograd error; fail fast instead.
+        if torch.is_grad_enabled() and not log_pf_trajectories.requires_grad:
+            raise RuntimeError(
+                "Reusing saved log-probs that are detached from the autograd graph "
+                "(sampling ran under no_grad, e.g. use_kv_cache=True), so backprop "
+                "would fail. Pass recalculate_all_logprobs=True to recompute them "
+                "(the estimator's teacher-forced loss recomputes them efficiently)."
+            )
     else:
 
         # Decide vectorized vs non-vectorized based on estimator capability
@@ -96,7 +194,19 @@ def get_trajectory_pfs(
         validate_policy_estimator(policy_pf, "pf")
         is_vectorized = bool(getattr(policy_pf, "is_vectorized", True))
 
-        if not is_vectorized:
+        # Opt-in teacher-forced (parallel) recompute: one causal forward over the whole
+        # trajectory instead of the per-step loop. Must be tested BEFORE the per-step
+        # branch, since recurrent estimators always report is_vectorized=False.
+        use_teacher_forcing = (
+            isinstance(policy_pf, RecurrentDiscretePolicyEstimator)
+            and policy_pf.teacher_forced_loss
+        )
+
+        if use_teacher_forcing:
+            log_pf_trajectories = _recurrent_teacher_forced_pfs(
+                policy_pf, trajectories, **policy_kwargs
+            )
+        elif not is_vectorized:
             # Per-step path.
             N = trajectories.batch_size
             device = trajectories.states.device
@@ -158,27 +268,18 @@ def get_trajectory_pfs(
                 log_pf_trajectories[t] = step_log_probs
 
         else:
-            state_mask = ~trajectories.states.is_sink_state
-            action_mask = ~trajectories.actions.is_dummy
-            # state_mask[-1] is all False
-            assert (
-                state_mask[:-1] == action_mask
-            ).all(), "Something wrong happening with log_pf evaluations"
-
+            # Vectorized path.
+            state_mask, action_mask = _pf_valid_masks(trajectories)
             valid_states = trajectories.states[state_mask]
             valid_actions = trajectories.actions[action_mask]
 
-            # Vectorized path.
-            # Allocate log_pf explicitly as floating point to avoid silent int casts.
-            log_pf_trajectories = torch.full(
-                trajectories.actions.tensor[..., 0].shape,
-                fill_value=0.0,
-                dtype=torch.get_default_dtype(),
-                device=trajectories.states.device,
-            )
-
             if len(valid_states) == 0:
-                return log_pf_trajectories
+                return torch.full(
+                    action_mask.shape,
+                    0.0,
+                    dtype=torch.get_default_dtype(),
+                    device=trajectories.states.device,
+                )
 
             # Build conditions per-step shape to align with valid_states
             masked_cond = None
@@ -209,9 +310,7 @@ def get_trajectory_pfs(
             )
 
             # Pad back to full batch size.
-            log_pf_trajectories[action_mask] = valid_log_pf_actions.to(
-                log_pf_trajectories.dtype, copy=False
-            )
+            log_pf_trajectories = _scatter_pf(action_mask, valid_log_pf_actions)
 
     assert log_pf_trajectories.shape == (
         trajectories.max_length,

--- a/testing/test_kv_cache.py
+++ b/testing/test_kv_cache.py
@@ -1,6 +1,6 @@
 """Correctness gates for the fixed-length KV-cache sampling optimization.
 
-Covers two layers:
+Covers three layers:
 
 - The transformer module's in-place preallocated carry (PR1a): incremental decode
   equals a single full-sequence forward, the buffers are preallocated and mutated in
@@ -8,6 +8,8 @@ Covers two layers:
 - The recurrent estimator's ``use_kv_cache`` toggle (PR1b): the cached fast path and
   the corrected full-prefix baseline produce identical per-step logits, both equal to
   a teacher-forced forward, and the fixed-length guard fires on ragged batches.
+- The teacher-forced (vectorized) loss recompute (PR2): equals the per-step recompute
+  and carries gradients.
 
 These are the gates the spec calls "load-bearing": they turn red on the previous
 (grow-both) recurrent path and green on the corrected implementation.
@@ -22,6 +24,7 @@ from gfn.estimators import RecurrentDiscretePolicyEstimator
 from gfn.gym.bitSequence import BitSequence
 from gfn.samplers import Sampler
 from gfn.utils.modules import TransformerDiscreteSequenceModel
+from gfn.utils.prob_calculations import get_trajectory_pfs
 
 ATOL = 1e-5
 
@@ -236,3 +239,70 @@ def test_sampling_runs_in_both_modes() -> None:
             )
         # Fixed-length: every trajectory has the same number of steps.
         assert trajs.max_length == env.words_per_seq + 1
+
+
+# --------------------------------------------------------------------------------
+# PR2: teacher-forced (vectorized) loss recompute
+# --------------------------------------------------------------------------------
+
+
+def test_teacher_forced_matches_per_step() -> None:
+    """Teacher-forced log_pf equals the per-step recompute (equivalence gate)."""
+    env, model = _env_and_model()
+    est = RecurrentDiscretePolicyEstimator(module=model, n_actions=env.n_actions)
+    trajs = Sampler(estimator=est).sample_trajectories(
+        env, n=8, save_logprobs=False, save_estimator_outputs=False
+    )
+
+    est.teacher_forced_loss = False
+    log_pf_perstep = get_trajectory_pfs(est, trajs, recalculate_all_logprobs=True)
+    est.teacher_forced_loss = True
+    log_pf_tf = get_trajectory_pfs(est, trajs, recalculate_all_logprobs=True)
+
+    assert log_pf_perstep.shape == log_pf_tf.shape
+    assert torch.allclose(log_pf_perstep, log_pf_tf, atol=ATOL)
+
+
+def test_teacher_forced_carries_gradients() -> None:
+    """The teacher-forced recompute is grad-bearing (loss can backprop through it)."""
+    env, model = _env_and_model()
+    est = RecurrentDiscretePolicyEstimator(module=model, n_actions=env.n_actions)
+    est.teacher_forced_loss = True
+    trajs = Sampler(estimator=est).sample_trajectories(
+        env, n=8, save_logprobs=False, save_estimator_outputs=False
+    )
+    model.zero_grad()
+    get_trajectory_pfs(est, trajs, recalculate_all_logprobs=True).sum().backward()
+    grad_total = sum(
+        p.grad.abs().sum().item() for p in model.parameters() if p.grad is not None
+    )
+    assert grad_total > 0.0
+
+
+def test_use_kv_cache_auto_enables_teacher_forcing() -> None:
+    """use_kv_cache=True auto-enables teacher_forced_loss so cached policies train."""
+    env, model = _env_and_model()
+    cached = RecurrentDiscretePolicyEstimator(
+        module=model, n_actions=env.n_actions, use_kv_cache=True
+    )
+    assert cached.teacher_forced_loss is True  # auto-coupled
+    explicit = RecurrentDiscretePolicyEstimator(
+        module=model, n_actions=env.n_actions, teacher_forced_loss=True
+    )
+    assert explicit.teacher_forced_loss is True  # standalone opt-in still works
+    default = RecurrentDiscretePolicyEstimator(module=model, n_actions=env.n_actions)
+    assert default.teacher_forced_loss is False  # off by default
+
+
+def test_detached_logprobs_guard() -> None:
+    """Reusing detached (no_grad cached) log-probs under a live graph fails fast."""
+    env, model = _env_and_model()
+    est = RecurrentDiscretePolicyEstimator(
+        module=model, n_actions=env.n_actions, use_kv_cache=True
+    )
+    trajs = Sampler(estimator=est).sample_trajectories(
+        env, n=4, save_logprobs=True, save_estimator_outputs=False
+    )
+    assert trajs.log_probs is not None and not trajs.log_probs.requires_grad
+    with pytest.raises(RuntimeError, match="detached"):
+        get_trajectory_pfs(est, trajs, recalculate_all_logprobs=False)

--- a/tutorials/examples/benchmark_kv_cache.py
+++ b/tutorials/examples/benchmark_kv_cache.py
@@ -6,9 +6,9 @@ Run me:
     python tutorials/examples/benchmark_kv_cache.py
     python tutorials/examples/benchmark_kv_cache.py --seq_sizes 16 32 64 128 --plot out.png
 
-I sample the *same* transformer policy on ``BitSequence`` two ways and time both, so the
-wall-clock difference is exactly the KV-cache. No GPU needed -- the win is a FLOP
-reduction and shows up on CPU (and grows with sequence length).
+I train/sample the *same* transformer policy on ``BitSequence`` two ways and time
+both, so the wall-clock difference is exactly the KV-cache. No GPU needed -- the win
+is a FLOP reduction and shows up on CPU (and grows with sequence length).
 
 ================================================================================
 WHY KV-CACHING HELPS
@@ -52,20 +52,26 @@ to one full-sequence forward):
     buffer at the cursor (no ``torch.cat``, no realloc) and attends against the filled
     prefix. This is the O(L^2) fast path.
 
-The autograd catch: writing K/V in place mutates a buffer whose earlier slice was saved
-for a previous step's backward, which invalidates the autograd graph. So the cached path
-runs under ``torch.no_grad()`` -- which is fine, because *sampling only needs sampled
-actions, not gradients*. This makes ``use_kv_cache=True`` ideal for inference/rollout;
-to *train* with it, recompute the loss log-probs with a grad-bearing forward
-(``recalculate_all_logprobs=True``). A companion "teacher-forced" parallel recompute
-makes that efficient and turns this sampling win into an end-to-end training win.
+The autograd catch (and why the design is split): writing K/V in place mutates a buffer
+whose earlier slice was saved for a previous step's backward, which invalidates the
+autograd graph. So the cached path runs under ``torch.no_grad()`` -- which is fine,
+because *sampling only needs sampled actions, not gradients*. Gradients are instead
+produced at loss time by a single **teacher-forced** (parallel, causal-masked) forward
+over each committed trajectory. ``use_kv_cache=True`` auto-enables this recompute
+(``teacher_forced_loss``); you just request it with
+``loss(..., recalculate_all_logprobs=True)``. That recompute is grad-safe and itself
+cheaper than back-propagating through an ``L``-step sequential rollout.
+
+    sampling (no_grad, cached, O(L^2))   +   loss (teacher-forced, grad, one forward)
 
 ================================================================================
 WHAT THIS SCRIPT MEASURES
 ================================================================================
-For each sequence length it (1) asserts the two configs produce identical per-step
-logits (``|Δ logits| ~ 1e-7`` -- proof it is the same model), then times pure rollout
-under ``no_grad`` for each -- isolating the cache (O(L^3) vs O(L^2)).
+For each sequence length it (1) asserts the two configs score identical log-probs
+(``|Δ log_pf| ~ 1e-7`` -- proof it is the same model), then times:
+  * **pure sampling** under ``no_grad`` -- isolates the cache (O(L^3) vs O(L^2));
+  * **full training step** (sample + loss + backward + optimizer) -- the realistic
+    cost, which also folds in the teacher-forced loss on the cached side.
 """
 
 from __future__ import annotations
@@ -100,13 +106,15 @@ def build(args, seq_size: int, use_kv_cache: bool, device: torch.device):
     """Construct ``(env, gflownet)`` for one benchmark configuration.
 
     This is the only place the KV-cache API appears -- everything else (sampler, loss,
-    optimizer) is the ordinary torchgfn stack, unchanged.
+    optimizer) is the ordinary torchgfn training stack, unchanged.
 
     Args:
         args: Parsed CLI arguments (model/env hyperparameters).
         seq_size: BitSequence length; with ``word_size=1`` this equals the number of
             autoregressive decode steps per trajectory (the ``L`` in the docstring).
-        use_kv_cache: Selects the sampling path (see module docstring).
+        use_kv_cache: Selects the sampling path (see module docstring). It also
+            auto-enables the teacher-forced loss recompute, since cached sampling is
+            ``no_grad`` and gradients must come from that recompute.
         device: Torch device.
 
     Returns:
@@ -136,7 +144,9 @@ def build(args, seq_size: int, use_kv_cache: bool, device: torch.device):
         module=model,
         n_actions=env.n_actions,
         is_backward=False,
-        # The single switch that turns on the in-place, feed-newest-token fast path.
+        # The single switch: turns on the in-place, feed-newest-token fast path and,
+        # because cached sampling is no_grad, auto-enables the teacher-forced loss
+        # recompute so the policy stays trainable.
         use_kv_cache=use_kv_cache,
     )
     # Tree-structured DAG (each string has a unique parent) => backward policy is
@@ -181,56 +191,86 @@ def time_sampling(gflownet, env, batch: int, device, warmup, iters):
     return _median_ms(_step, device, warmup, iters)
 
 
-def check_equivalence(args, seq_size: int, device: torch.device) -> float:
-    """Prove the cache changes speed, not results, at the per-step logit level.
+def time_training_step(
+    gflownet, env, batch: int, use_kv_cache: bool, device, warmup, iters
+):
+    """Time a full training step: sample + loss + backward + optimizer step.
 
-    We reconstruct the states at every decode step of a fixed batch and run the
-    estimator over them both ways (``use_kv_cache`` False and True). Because the cached
-    incremental decode equals the full-prefix forward, the logits must agree to
-    floating-point tolerance; a large gap would mean the cache computes the wrong thing.
-    Returns the max absolute logit difference.
+    The two realistic end-to-end configurations differ in *how gradients are obtained*:
+
+      * baseline: grad-bearing sequential sampling saves per-step log-probs, and the
+        loss reuses them (``save_logprobs=True``, ``recalculate_all_logprobs=False``);
+      * cached: ``no_grad`` cached sampling saves nothing differentiable, so the loss
+        recomputes log-probs with the teacher-forced parallel forward
+        (``recalculate_all_logprobs=True``; teacher forcing is auto-enabled by
+        ``use_kv_cache``).
     """
+    optimizer = torch.optim.Adam(gflownet.pf_pb_parameters(), lr=1e-3)
+    optimizer.add_param_group({"params": gflownet.logz_parameters(), "lr": 1e-1})
+
+    def _step():
+        trajectories = gflownet.sample_trajectories(
+            env,
+            n=batch,
+            # Cached sampling is no_grad, so saving its log-probs would be pointless
+            # (they carry no gradient); recompute them in the loss instead.
+            save_logprobs=not use_kv_cache,
+            save_estimator_outputs=False,
+        )
+        optimizer.zero_grad()
+        loss = gflownet.loss(env, trajectories, recalculate_all_logprobs=use_kv_cache)
+        loss.backward()
+        optimizer.step()
+
+    return _median_ms(_step, device, warmup, iters)
+
+
+def check_equivalence(args, seq_size: int, device: torch.device) -> float:
+    """Prove the cache changes speed, not results, by scoring one batch two ways.
+
+    We sample a batch once, then recompute its forward log-probs with (a) the per-step
+    path and (b) the teacher-forced path over the *same* module weights. Because the
+    module's parallel forward equals its incremental decode, these must agree to
+    floating-point tolerance; a large gap would mean the cache is computing the wrong
+    thing. Returns the max absolute difference in per-step ``log P_F``.
+    """
+    from gfn.utils.prob_calculations import get_trajectory_pfs
+
     set_seed(args.seed)
     env, gflownet = build(args, seq_size, use_kv_cache=False, device=device)
-    # Both estimators wrap the SAME module weights, so the only difference is the path.
-    model = gflownet.pf.module
-    est_off = RecurrentDiscretePolicyEstimator(
-        module=model, n_actions=env.n_actions, use_kv_cache=False
+    est = gflownet.pf
+    trajectories = gflownet.sample_trajectories(
+        env, n=args.batch_size, save_logprobs=False, save_estimator_outputs=False
     )
-    est_on = RecurrentDiscretePolicyEstimator(
-        module=model, n_actions=env.n_actions, use_kv_cache=True
+    # Per-step recompute (baseline scoring): est has teacher_forced_loss=False.
+    log_pf_baseline = get_trajectory_pfs(
+        est, trajectories, recalculate_all_logprobs=True
     )
-
-    batch, L = args.batch_size, env.words_per_seq
-    words = torch.randint(0, env.n_actions - 1, (batch, L), device=device)
-
-    def per_step_logits(est) -> torch.Tensor:
-        carry = est.init_carry(batch, device)
-        out = []
-        with torch.no_grad():
-            for t in range(L + 1):  # steps 0..L (L+1 decode steps)
-                tensor = words.clone()
-                tensor[:, t:] = -1  # only first t words committed
-                logits, carry = est(env.States(tensor), carry)
-                out.append(logits)
-        return torch.stack(out, dim=0)
-
-    return (per_step_logits(est_off) - per_step_logits(est_on)).abs().max().item()
+    # Teacher-forced recompute (cached scoring): a sibling estimator over the SAME
+    # module weights, so the only difference is the recompute path.
+    est_tf = RecurrentDiscretePolicyEstimator(
+        module=est.module, n_actions=env.n_actions, teacher_forced_loss=True
+    )
+    log_pf_cached = get_trajectory_pfs(
+        est_tf, trajectories, recalculate_all_logprobs=True
+    )
+    return (log_pf_baseline - log_pf_cached).abs().max().item()
 
 
 def main(args) -> None:
     device = torch.device(args.device)
+    torch.set_grad_enabled(True)
     print(
         f"device={device}  batch={args.batch_size}  "
         f"model=(dim={args.embedding_dim}, heads={args.num_heads}, "
         f"layers={args.num_layers})  word_size={args.word_size}\n"
     )
 
-    # Columns: sampling base/cache + speedup, and the equivalence residual proving both
-    # columns describe the same model.
+    # Columns: sampling base/cache + speedup, training base/cache + speedup, and the
+    # equivalence residual proving both columns describe the same model.
     header = (
-        f"{'seq_len':>7} | {'sample base':>12} {'sample cache':>13} "
-        f"{'speedup':>8} | {'|Δlogits|':>10}"
+        f"{'seq_len':>7} | {'sample base':>12} {'sample cache':>13} {'x':>5} | "
+        f"{'train base':>11} {'train cache':>12} {'x':>5} | {'|Δlogpf|':>9}"
     )
     print(header)
     print("-" * len(header))
@@ -243,7 +283,7 @@ def main(args) -> None:
         max_delta = check_equivalence(args, seq_size, device)
         assert (
             max_delta < 1e-4
-        ), f"baseline vs cached logits differ by {max_delta} at seq_size={seq_size}"
+        ), f"baseline vs cached log_pf differ by {max_delta} at seq_size={seq_size}"
 
         # Fresh models per config so neither warms the other's caches/allocator.
         env_b, gfn_b = build(args, seq_size, use_kv_cache=False, device=device)
@@ -255,18 +295,36 @@ def main(args) -> None:
         s_cache = time_sampling(
             gfn_c, env_c, args.batch_size, device, args.warmup, args.iters
         )
-        speedup = s_base[0] / s_cache[0]
-        rows.append((seq_size, s_base[0], s_cache[0], speedup))
+        t_base = time_training_step(
+            gfn_b, env_b, args.batch_size, False, device, args.warmup, args.iters
+        )
+        t_cache = time_training_step(
+            gfn_c, env_c, args.batch_size, True, device, args.warmup, args.iters
+        )
+
+        sample_speedup = s_base[0] / s_cache[0]
+        train_speedup = t_base[0] / t_cache[0]
+        rows.append(
+            (
+                seq_size,
+                s_base[0],
+                s_cache[0],
+                sample_speedup,
+                t_base[0],
+                t_cache[0],
+                train_speedup,
+            )
+        )
         print(
             f"{seq_size:>7} | {s_base[0]:>10.2f}ms {s_cache[0]:>11.2f}ms "
-            f"{speedup:>7.1f}x | {max_delta:>10.1e}"
+            f"{sample_speedup:>4.1f}x | {t_base[0]:>9.2f}ms {t_cache[0]:>10.2f}ms "
+            f"{train_speedup:>4.1f}x | {max_delta:>9.1e}"
         )
 
     print(
-        "\nBoth configs are numerically identical (see |Δlogits|); the speedup is the "
-        "KV-cache.\nIt isolates the sampling win (O(L^3)->O(L^2)) and widens with "
-        "seq_len -- that is the point.\nTo turn this into an end-to-end training "
-        "speedup, pair it with the teacher-forced loss recompute."
+        "\nBoth configs are numerically identical (see |Δlogpf|); the speedup is the "
+        "KV-cache.\nSampling isolates the cache (O(L^3)->O(L^2)); training-step folds in "
+        "the teacher-forced loss. The gap widens with seq_len -- that is the point."
     )
 
     if args.plot:
@@ -274,7 +332,7 @@ def main(args) -> None:
 
 
 def _save_plot(rows, path: str) -> None:
-    """Optionally save a sampling-time / speedup figure (requires matplotlib)."""
+    """Optionally save a speedup-vs-length figure (requires matplotlib)."""
     try:
         import matplotlib
 
@@ -295,13 +353,13 @@ def _save_plot(rows, path: str) -> None:
     )
     ax1.legend()
     ax1.grid(alpha=0.3)
-    ax2.plot(seq, [r[3] for r in rows], "o-")
+    ax2.plot(seq, [r[3] for r in rows], "o-", label="sampling")
+    ax2.plot(seq, [r[6] for r in rows], "s-", label="training step")
     ax2.axhline(1.0, color="gray", ls="--", lw=0.8)
     ax2.set(
-        xlabel="sequence length (steps)",
-        ylabel="speedup (x)",
-        title="KV-cache sampling speedup",
+        xlabel="sequence length (steps)", ylabel="speedup (x)", title="KV-cache speedup"
     )
+    ax2.legend()
     ax2.grid(alpha=0.3)
     fig.tight_layout()
     fig.savefig(path, dpi=120)


### PR DESCRIPTION
## Summary

**Stacks on #525** (fixed-length KV-cache). With `use_kv_cache=True`, sampling runs under `no_grad`, so gradients must come from a loss-time recompute. torchgfn's existing recompute for recurrent estimators (`is_vectorized=False`) re-runs the estimator **per step**, re-paying the sequential rollout cost inside the loss.

This PR adds an **opt-in teacher-forced (parallel) recompute**: one causal forward over the whole committed trajectory `[BOS, w0, …, w_{L-1}]`, gathering per-step action log-probs. It **reuses the estimator's own full-prefix forward**, so the loss-time input is built identically to sampling; the result matches the per-step path to tolerance (`atol=1e-5`) with a **single grad-bearing forward** and a **shallow** autograd graph.

## Changes

- **`RecurrentDiscretePolicyEstimator(teacher_forced_loss=…)`** — recompute PF log-probs with one parallel forward per trajectory instead of the per-step loop. **Auto-enabled by `use_kv_cache`**, so a cached policy stays trainable out of the box (you only pass `recalculate_all_logprobs=True` at loss time).
- **`get_trajectory_pfs`** takes a teacher-forced branch for recurrent estimators; the per-step / vectorized paths are unchanged (their shared mask + scatter bookkeeping is now factored into small helpers). Fixed-length trajectories only (guarded; see the Gap-2 `TODO`).
- **Fail-fast guard**: `get_trajectory_pfs` now raises an actionable error when asked to reuse detached (`no_grad`-sampled) log-probs under an active autograd graph, instead of the previous opaque `backward()` failure.

## Result

Together with `use_kv_cache=True` (`recalculate_all_logprobs=True`), this turns the sampling win into an **end-to-end training speedup**.

Measured on this branch — single CPU run (Apple Silicon), batch 32, dim 64 / 4 heads / 2 layers, `word_size=1`:

| seq_len | sample base | sample cached | sampling ×| train base | train cached | training × | \|Δ log_pf\| |
|--:|--:|--:|:--:|--:|--:|:--:|:--:|
| 8  | 15.36 ms | 10.62 ms | 1.4× | 38.92 ms | 17.53 ms | 2.2× | 2.4e-07 |
| 16 | 38.27 ms | 19.99 ms | 1.9× | 93.00 ms | 33.02 ms | 2.8× | 3.6e-07 |
| 32 | 120.12 ms | 44.14 ms | 2.7× | 268.07 ms | 59.86 ms | 4.5× | 3.6e-07 |
| 64 | 424.81 ms | 102.28 ms | **4.2×** | 899.33 ms | 131.55 ms | **6.8×** | 3.6e-07 |

The `|Δ log_pf|` residual is the equivalence gate: both configurations are the same model, so the wall-clock gap is the optimization. Absolute figures are CPU- and machine-dependent and vary run to run; the robust claim is the **trend** — the training-step gap widens with sequence length, because the cached rollout is O(L²) instead of O(L³) *and* the loss recompute collapses to one parallel forward.

## Tests

`testing/test_kv_cache.py`: teacher-forced `log_pf` == per-step recompute; the teacher-forced path carries gradients; `use_kv_cache` auto-enables `teacher_forced_loss`; and the detached-log-probs guard fires with an actionable message.

## Unaffected

Non-recurrent estimators and the default (`teacher_forced_loss=False`) path are unchanged. Stateless policies and the `Sampler` API are unaffected. Full `testing/` suite green on this branch.

> Review note: this PR is stacked on #525, so its diff is shown against `feat/kv-cache`. Please merge #525 first (GitHub will then retarget this PR to `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
